### PR TITLE
Address some small issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The EventFlow suite supports .NET applications and .NET Core applications. It al
 ## Getting Started
 1. To quickly get started, you can create a simple console application in VisualStudio and install the nuget package Microsoft.Diagnostics.EventFlow. The package is still in preview, if you're installing the package from Manage NuGet Packages window, please check **"Include prerelease"**.
 2. After the nuget package is installed, there should be a eventFlowConfig.json file added to the project. This file contains default configuration for the EventFlow pipeline. A few sections with optional configuration elements are commented outs. These sections can be enabled as desired. Here is what the file looks like
-```json
+```js
 {
     "inputs": [
         // {

--- a/src/Microsoft.Diagnostics.EventFlow.Core/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/project.json
@@ -33,10 +33,10 @@
     "delaySign": true
   },
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "Microsoft Diagnostics EventFlow Core",
     "tags": [
       "Microsoft",

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/project.json
@@ -20,10 +20,10 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Tracing.EventSource infrastructure.",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "EventSource input for Microsoft Diagnostics EventFlow",
     "tags": [
       "Microsoft",

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/project.json
@@ -16,10 +16,10 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an input implementation for capturing data from Windows performance counters.",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "Performance Counter input for Microsoft Diagnostics EventFlow",
     "tags": [
       "Microsoft",

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/project.json
@@ -24,10 +24,10 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Trace infrastructure.",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "Trace input for for Microsoft Diagnostics EventFlow",
     "tags": [
       "Microsoft",

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/project.json
@@ -17,10 +17,10 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an output implementation that sends diagnostics data to Microsoft Application Insights service.",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "Application Insights output for Microsoft Diagnostics EventFlow",
     "tags": [
       "Microsoft",

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/project.json
@@ -21,10 +21,10 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an output implementation that sends diagnostics data to Elasticsearch.",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "Elasticsearch output for Microsoft Diagnostics EventFlow",
     "tags": [
       "Microsoft",

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/project.json
@@ -19,10 +19,10 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an output implementation that sends diagnostics data to Azure Event Hubs.",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "Azure Event Hubs output for Microsoft Diagnostics EventFlow",
     "tags": [
       "Microsoft",

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/project.json
@@ -20,7 +20,6 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an output implementation that sends diagnostics data to Microsoft Operations Management Suite."
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/project.json
@@ -22,10 +22,10 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an output implementation that sends diagnostics data to standard output stream (useful for debugging purposes).",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "Standard output for Microsoft Diagnostics EventFlow",
     "tags": [
       "Microsoft",

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage/project.json
@@ -16,7 +16,6 @@
     "delaySign": true
   },
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides an output implementation that sends diagnostics data to Azure Table Storage."
 }

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/project.json
@@ -20,10 +20,10 @@
   },
 
   "authors": [ "Microsoft" ],
-  "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "description": "Provides types that simplify the use of EventFlow library by Microsoft Service Fabric services.",
   "packOptions": {
+    "projectUrl": "https://github.com/Azure/diagnostics-eventflow",
     "summary": "Support components for Service Fabic to use Microsoft Diagnostics EventFlow",
     "tags": [
       "Microsoft",


### PR DESCRIPTION
- Workaround json comment in Readme.MD, which has some invalid syntax.
- Relocate projectUrls for nuget packages to address build warnings.