### PR TITLE
Elevate PerformanceCounter input to preview quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ EventFlow PerformanceCounter input supports the first method of deterimining cou
 | counterCategory | string | Yes | Category of the performance counter to monitor |
 | counterName | string | Yes | Name of the counter to monitor. |
 | collectionIntervalMsec | integer | No | Sampling interval for the counter. Values for the counter are read not more often than at this rate. Default is 30 seconds. |
-| processIdCounterCategory and processIdCounterName | string | No | The category and name of the performance counter that provides process ID to counter instance name mapping. It is not necessary to specify these "Process" counter category and for .NET performance counters. |
+| processIdCounterCategory and processIdCounterName | string | No | The category and name of the performance counter that provides process ID to counter instance name mapping. It is not necessary to specify these for the "Process" counter category and for .NET performance counters. |
 | useDotNetInstanceNameConvention | boolean | No | Indicates that the counter instance names include process ID as described in [ProcessNameFormat documentation](https://msdn.microsoft.com/en-us/library/dd537616.aspx). |
 
 *Important usage note*

--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ EventFlow PerformanceCounter input supports the first method of deterimining cou
 | processIdCounterCategory and processIdCounterName | string | No | The category and name of the performance counter that provides process ID to counter instance name mapping. It is not necessary to specify these "Process" counter category and for .NET performance counters. |
 | useDotNetInstanceNameConvention | boolean | No | Indicates that the counter instance names include process ID as described in [ProcessNameFormat documentation](https://msdn.microsoft.com/en-us/library/dd537616.aspx). |
 
+*Important usage note*
+
+Some performance counters require administrative privileges to be read. This can manifest itself by health reporter reporting 
+"category does not exist" errors from PerformanceCounter output, despite the fact that the category and counter are properly configured
+and clearly visible in Windows Performance Monitor. If you need to consume such counters, make sure your process runs under an account
+that is part of the local Administrators group.  
+
 ### Outputs
 Outputs define where data will be published from the engine. It's an error if there are no outputs defined. Each output type has its own set of parameters.
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DiagnosticPipelineFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DiagnosticPipelineFactory.cs
@@ -31,12 +31,15 @@ namespace Microsoft.Diagnostics.EventFlow
             return CreatePipeline(config);
         }
 
-        public static DiagnosticPipeline CreatePipeline(IConfiguration configuration)
+        public static DiagnosticPipeline CreatePipeline(IConfiguration configuration, IHealthReporter healthReporter = null)
         {
             Requires.NotNull(configuration, nameof(configuration));
 
-            IHealthReporter healthReporter = CreateHealthReporter(configuration);
-            Requires.NotNull(healthReporter, nameof(healthReporter));
+            if (healthReporter == null)
+            {
+                healthReporter = CreateHealthReporter(configuration);
+            }
+            Verify.Operation(healthReporter != null, $"An instance of a health reporter could not be created and none was provider as a parameter to {nameof(CreatePipeline)} method");
             (healthReporter as IRequireActivation)?.Activate();
 
             IDictionary<string, string> inputFactories;

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/Configuration/PerformanceCounterInputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/Configuration/PerformanceCounterInputConfiguration.cs
@@ -12,5 +12,11 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
     public class PerformanceCounterInputConfiguration: ItemConfiguration
     {
         public List<PerformanceCounterConfiguration> Counters { get; set; }
+        public int SampleIntervalMsec { get; set; }
+
+        public PerformanceCounterInputConfiguration()
+        {
+            this.SampleIntervalMsec = 10000;  // Default sample interval 10 seconds
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/ProcessInstanceNameCache.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/ProcessInstanceNameCache.cs
@@ -1,0 +1,86 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.EventFlow.Configuration;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow.Inputs
+{
+    internal class ProcessInstanceNameCache
+    {
+        private Dictionary<CacheKey, string> instanceNames = new Dictionary<CacheKey, string>();
+
+        public string GetCounterInstanceNameForCurrentProcess(PerformanceCounterConfiguration counterConfiguration)
+        {
+            Requires.NotNull(counterConfiguration, nameof(counterConfiguration));
+
+            var key = new CacheKey(counterConfiguration.ProcessIdCounterCategory, counterConfiguration.ProcessIdCounterName);
+            string instanceName;
+            if (this.instanceNames.TryGetValue(key, out instanceName))
+            {
+                return instanceName;
+            }
+
+            Process currentProcess = Process.GetCurrentProcess();
+
+            if (counterConfiguration.UseDotNetInstanceNameConvention)
+            {
+                instanceName = VersioningHelper.MakeVersionSafeName(currentProcess.ProcessName, ResourceScope.Machine, ResourceScope.AppDomain);
+                // We actually don't need the AppDomain portion, but there is no way to get the runtime ID without AppDomain id attached.
+                // So we just filter it out 
+                int adIdIndex = instanceName.LastIndexOf("_ad");
+                if (adIdIndex > 0)
+                {
+                    instanceName = instanceName.Substring(0, adIdIndex);
+                }
+                this.instanceNames[key] = instanceName;
+                return instanceName;
+            }
+            else
+            {
+                PerformanceCounterCategory category = new PerformanceCounterCategory(counterConfiguration.ProcessIdCounterCategory);
+
+                string[] processInstanceNames = category.GetInstanceNames()
+                    .Where(inst => inst.StartsWith(currentProcess.ProcessName))
+                    .ToArray();
+
+                foreach (string processInstanceName in processInstanceNames)
+                {
+                    using (PerformanceCounter cnt = new PerformanceCounter(counterConfiguration.ProcessIdCounterCategory, counterConfiguration.ProcessIdCounterName, processInstanceName, readOnly: true))
+                    {
+                        int val = (int)cnt.RawValue;
+                        if (val == currentProcess.Id)
+                        {
+                            this.instanceNames[key] = processInstanceName;
+                            return processInstanceName;
+                        }
+                    }
+                }
+            }
+
+            this.instanceNames[key] = null;
+            return null;
+        }
+
+        public void Clear()
+        {
+            this.instanceNames.Clear();
+        }
+
+        private class CacheKey : Tuple<string, string>
+        {
+            public CacheKey(string counterCategory, string counterName) : base(counterCategory, counterName) { }
+
+            public string CounterCategory { get { return this.Item1; } }
+            public string CounterName { get { return this.Item2; } }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/TrackedPerformanceCounter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/TrackedPerformanceCounter.cs
@@ -1,0 +1,77 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Diagnostics.EventFlow.Configuration;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow.Inputs
+{
+    internal class TrackedPerformanceCounter : IDisposable
+    {
+        private PerformanceCounter counter;
+        private bool disposed;
+        private DateTimeOffset lastAccessedOn;
+        private string lastInstanceName;
+
+        public PerformanceCounterConfiguration Configuration { get; private set; }
+
+        public TrackedPerformanceCounter(PerformanceCounterConfiguration configuration)
+        {
+            Requires.NotNull(configuration, nameof(configuration));
+
+            this.Configuration = configuration;
+            this.lastAccessedOn = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(1));
+            this.disposed = false;
+        }
+
+        public bool SampleNextValue(ProcessInstanceNameCache processInstanceNameCache, out float newValue)
+        {
+            Requires.NotNull(processInstanceNameCache, nameof(processInstanceNameCache));
+
+            newValue = 0;
+            if (disposed)
+            {
+                return false;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            if (now - this.lastAccessedOn < TimeSpan.FromMilliseconds(this.Configuration.SamplingIntervalMsec))
+            {
+                return false;
+            }
+
+            string instanceName = processInstanceNameCache.GetCounterInstanceNameForCurrentProcess(this.Configuration);
+            this.lastAccessedOn = now;
+            if (this.counter == null || (!string.IsNullOrEmpty(instanceName) && instanceName != this.lastInstanceName))
+            {
+                if (this.counter != null)
+                {
+                    this.counter.Dispose();
+                }
+                this.counter = new PerformanceCounter(
+                    this.Configuration.CounterCategory,
+                    this.Configuration.CounterName,
+                    instanceName,
+                    readOnly: true);
+            }
+            this.lastInstanceName = instanceName;
+
+            newValue = this.counter.NextValue();
+            return true;
+        }
+
+        public void Dispose()
+        {
+            if (this.counter != null)
+            {
+                this.counter.Dispose();
+                this.counter = null;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/TrackedPerformanceCounter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/TrackedPerformanceCounter.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             Requires.NotNull(configuration, nameof(configuration));
 
             this.Configuration = configuration;
+            // Set the lastAccessedOn time way in the past so that the data is sampled at startup
             this.lastAccessedOn = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(1));
             this.disposed = false;
         }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
@@ -102,8 +102,10 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                 {
                     this.ReportEsRequestError(response, "Bulk upload");
                 }
-
-                this.healthReporter.ReportHealthy();
+                else
+                {
+                    this.healthReporter.ReportHealthy();
+                }
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
             ConfigurationBuilder configBuilder = new ConfigurationBuilder();
             configBuilder.AddJsonFile(configFilePath);
             IConfigurationRoot configurationRoot = configBuilder.Build();
-            return DiagnosticPipelineFactory.CreatePipeline(configurationRoot);
+            return DiagnosticPipelineFactory.CreatePipeline(configurationRoot, new ServiceFabricHealthReporter(healthEntityName));
         }
     }
 }

--- a/tools/createNugetPackages.cmd
+++ b/tools/createNugetPackages.cmd
@@ -3,14 +3,18 @@ pushd "%~dp0.."
 SET parentDir=%cd%
 popd
 
+SET CONFIGURATION=%2
+IF '%CONFIGURATION%' == '' SET CONFIGURATION=Release
+
 SET SUFFIX=%1
 IF '%SUFFIX%' == '' GOTO NOSUFFIX
-for /f %%a in ('findstr /sm packOptions %parentDir%\src\project.json') do dotnet pack %%a --no-build -c Release -o "%parentDir%\nugets" --version-suffix %SUFFIX%
+
+for /f %%a in ('findstr /sm packOptions %parentDir%\src\project.json') do dotnet pack %%a --no-build -c %CONFIGURATION% -o "%parentDir%\nugets" --version-suffix %SUFFIX%
 "%~dp0\nuget.exe" pack "%parentDir%\nuspecs\Suite\Microsoft.Diagnostics.EventFlow.Suite.nuspec" -OutputDirectory "%parentDir%\nugets" -Suffix %SUFFIX%
 GOTO END
 
 :NOSUFFIX
-for /f %%a in ('findstr /sm packOptions %parentDir%\src\project.json') do dotnet pack %%a --no-build -c Release -o "%parentDir%\nugets"
+for /f %%a in ('findstr /sm packOptions %parentDir%\src\project.json') do dotnet pack %%a --no-build -c %CONFIGURATION% -o "%parentDir%\nugets"
 "%~dp0\nuget.exe" pack "%parentDir%\nuspecs\Suite\Microsoft.Diagnostics.EventFlow.Suite.nuspec" -OutputDirectory "%parentDir%\nugets"
 GOTO END
 


### PR DESCRIPTION
1. Make PerformanceCounter input preview-ready
2. A couple of minor bug fixes for ElasticSearch output and Service Fabric platform support
3. Add capability to build Debug version of Nuget packages to our Nuget build script
