### PR TITLE
Implement event context

### DIFF
--- a/Warsaw.sln
+++ b/Warsaw.sln
@@ -108,6 +108,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuspecs", "Nuspecs", "{3B5E
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Diagnostics.EventFlow.Inputs.Serilog", "src\Microsoft.Diagnostics.EventFlow.Inputs.Serilog\Microsoft.Diagnostics.EventFlow.Inputs.Serilog.xproj", "{C80DF85E-9756-4E30-989F-0D160B444F39}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp", "src\Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp\Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp.xproj", "{320377E7-BA11-42AA-BDE1-29BA875CE34B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -292,6 +294,14 @@ Global
 		{C80DF85E-9756-4E30-989F-0D160B444F39}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C80DF85E-9756-4E30-989F-0D160B444F39}.Release|x64.ActiveCfg = Release|Any CPU
 		{C80DF85E-9756-4E30-989F-0D160B444F39}.Release|x64.Build.0 = Release|Any CPU
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B}.Debug|x64.Build.0 = Debug|Any CPU
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B}.Release|x64.ActiveCfg = Release|Any CPU
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -319,5 +329,6 @@ Global
 		{15E2ED90-4B9A-42BD-97BB-C6AD2B1863AF} = {D67068AF-16BB-4037-BE4E-B642419089BA}
 		{69AA6421-82A5-43BF-AD27-8E2C172FF8CE} = {FC86C736-6428-431B-B83F-940BF7182757}
 		{C80DF85E-9756-4E30-989F-0D160B444F39} = {47200F40-43E1-4B09-B803-A921FED2BF05}
+		{320377E7-BA11-42AA-BDE1-29BA875CE34B} = {D67068AF-16BB-4037-BE4E-B642419089BA}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp.xproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\targets\DotNet\Microsoft.DotNet.Props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>320377e7-ba11-42aa-bde1-29ba875ce34b</ProjectGuid>
+    <RootNamespace>Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="..\..\targets\DotNet\Microsoft.DotNet.targets" />
+</Project>

--- a/src/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp/Program.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp/Program.cs
@@ -1,0 +1,75 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Diagnostics.Correlation.Common;
+using Newtonsoft.Json;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp
+{
+    public class CorrelationTelemetryInitializer : ITelemetryInitializer
+    {
+        public void Initialize(ITelemetry telemetry)
+        {
+            //add request id to every event
+            var ctx = ContextResolver.GetRequestContext<MyContext>();
+            if (ctx != null)
+            {
+                telemetry.Context.Operation.Id = ctx.CorrelationId;
+            }
+        }
+    }
+
+    class MyContext
+    {
+        public string CorrelationId;
+        public string OtherId;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            using (JsonWriter writer = new JsonTextWriter(new StringWriter(sb)))
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName(nameof(CorrelationId));
+                writer.WriteValue(CorrelationId);
+                writer.WritePropertyName(nameof(OtherId));
+                writer.WriteValue(OtherId);
+                writer.WriteEnd();
+                writer.WriteEndObject();
+            }
+            return sb.ToString();
+        }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            TelemetryConfiguration.Active.TelemetryInitializers.Add(new CorrelationTelemetryInitializer());
+            TelemetryConfiguration.Active.TelemetryChannel.DeveloperMode = true;
+
+            using (DiagnosticPipeline pipeline = DiagnosticPipelineFactory.CreatePipeline("config.json"))
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    ContextResolver.SetRequestContext(new MyContext
+                    {
+                        CorrelationId = Guid.NewGuid().ToString(),
+                        OtherId = i.ToString()
+                    });
+                    Trace.TraceWarning($"{DateTime.UtcNow:o} this is log message");
+                }
+                Task.Delay(10000).Wait();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp/config.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp/config.json
@@ -1,0 +1,28 @@
+﻿{
+  "healthReporter": {
+    "type": "CsvHealthReporter",
+    "logFileFolder": ".",
+    "logFilePrefix": "HealthReport",
+    "minReportLevel": "Warning",
+    "throttlingPeriodMsec": "1000"
+  },
+  "inputs": [
+    {
+      "type": "Trace",
+      "traceLevel": "Warning"
+    }
+  ],
+  "filters": [
+  ],
+  "outputs": [
+    {
+      "type": "ApplicationInsights",
+      "instrumentationKey": "**REMOVED**"
+    },
+    {
+      "type": "StdOutput"
+    }
+  ],
+
+  "schema-version": "2016-08-11"
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Consumers.EventContextConsoleApp/project.json
@@ -1,0 +1,23 @@
+﻿{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "copyToOutput": { "includeFiles": [ "config.json" ] }
+  },
+
+  "dependencies": {
+    "Microsoft.ApplicationInsights": "2.1.0",
+    "Microsoft.Diagnostics.Correlation.Common": "1.0.0-preview1",
+    "Microsoft.Diagnostics.EventFlow.Core": "1.0.0-*",
+    "Microsoft.Diagnostics.EventFlow.Inputs.Trace": "1.0.0-*",
+    "Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights": "1.0.0-*",
+    "Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch": "1.0.0-*",
+    "Microsoft.Diagnostics.EventFlow.Outputs.EventHub": "1.0.0-*",
+    "Microsoft.Diagnostics.EventFlow.Outputs.StdOutput": "1.0.0-*"
+  },
+
+  "frameworks": {
+    "net461": {
+    }
+  }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark/Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark/Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark.csproj
@@ -57,6 +57,12 @@
     <Reference Include="..\Microsoft.Diagnostics.EventFlow.Inputs.EventSource\bin\$(Configuration)\net46\Microsoft.Diagnostics.EventFlow.Inputs.EventSource.dll">
       <Name>Microsoft.Diagnostics.EventFlow.Inputs.EventSource</Name>
     </Reference>
+    <Reference Include="Microsoft.Diagnostics.Correlation.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Diagnostics.Correlation.Common.1.0.0-preview1\lib\net46\Microsoft.Diagnostics.Correlation.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Remoting" />
     <Reference Include="Validation, Version=2.3.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Validation.2.3.7\lib\dotnet\Validation.dll</HintPath>
       <Private>True</Private>

--- a/src/Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark/Program.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark/Program.cs
@@ -5,11 +5,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Microsoft.Diagnostics.EventFlow;
+using Microsoft.Diagnostics.Correlation.Common;
 using Microsoft.Diagnostics.EventFlow.Configuration;
 using Microsoft.Diagnostics.EventFlow.Inputs;
 using Microsoft.Diagnostics.EventFlow.Filters;
@@ -79,6 +75,7 @@ namespace Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark
                     name = "ImportantEvent";
                 }
 
+                ContextResolver.SetRequestContext(new {correlationId = eventSequenceNo});
                 BenchmarkEventSource.Log.ComplexMessage(
                     Guid.NewGuid(), 
                     Guid.NewGuid(), 

--- a/src/Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark/packages.config
+++ b/src/Microsoft.Diagnostics.EventFlow.Consumers.SimpleBenchmark/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Diagnostics.Correlation.Common" version="1.0.0-preview1" targetFramework="net46" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Extensions.Primitives" version="1.0.0" targetFramework="net46" />
   <package id="System.Linq" version="4.1.0" targetFramework="net46" />

--- a/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/Microsoft.Diagnostics.EventFlow.FilterParserGenerator.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/Microsoft.Diagnostics.EventFlow.FilterParserGenerator.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Diagnostics.Correlation.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Diagnostics.Correlation.Common.1.0.0-preview1\lib\net45\Microsoft.Diagnostics.Correlation.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Pegasus.Common">
       <HintPath>..\..\packages\Pegasus.3.1.2\lib\net40\Pegasus.Common.dll</HintPath>
       <Private>True</Private>
@@ -42,6 +46,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/packages.config
+++ b/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Diagnostics.Correlation.Common" version="1.0.0-preview1" targetFramework="net452" />
   <package id="Pegasus" version="3.1.2" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.2.0" targetFramework="net452" />
   <package id="Validation" version="2.3.7" targetFramework="net452" />

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventDataExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventDataExtensions.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Diagnostics.Tracing;
 using System.Diagnostics;
+using Microsoft.Diagnostics.Correlation.Common;
 
 namespace Microsoft.Diagnostics.EventFlow.Inputs
 {
@@ -29,6 +30,11 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             eventPayload["EventId"] = eventSourceEvent.EventId;
             eventPayload["EventName"] = eventSourceEvent.EventName;
             eventPayload["ActivityID"] = ActivityPathString(eventSourceEvent.ActivityId);
+            var eventContext = ContextResolver.GetRequestContext<object>();
+            if (eventContext != null)
+            {
+                eventPayload["EventContext"] = eventContext;
+            }
 
             try
             {

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/project.json
@@ -2,6 +2,7 @@
   "version": "1.0.0-*",
 
   "dependencies": {
+    "Microsoft.Diagnostics.Correlation.Common": "1.0.0-preview1",
     "Microsoft.Diagnostics.EventFlow.Core": { "target": "project" },
     "NETStandard.Library": "1.6.0"
   },

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/TraceInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/TraceInput.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using Microsoft.Diagnostics.Correlation.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Diagnostics.EventFlow.Configuration;
 
@@ -198,6 +199,12 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
                 if (!string.IsNullOrEmpty(relatedActivityId))
                 {
                     eventPayload["RelatedActivityID"] = relatedActivityId;
+                }
+
+                var eventContext = ContextResolver.GetRequestContext<object>();
+                if (eventContext != null)
+                {
+                    eventPayload["EventContext"] = eventContext;
                 }
 
                 this.subject.OnNext(eventEntry);

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/project.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "Microsoft.Diagnostics.EventFlow.Core": {
       "target": "project"
-    }
+    },
+    "Microsoft.Diagnostics.Correlation.Common" : "1.0.0-preview1"
   },
 
   "frameworks": {

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/ApplicationInsightsOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/ApplicationInsightsOutput.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Diagnostics.Correlation.Common;
 using Microsoft.Diagnostics.EventFlow.Configuration;
 using Microsoft.Diagnostics.EventFlow.Metadata;
 using Microsoft.Extensions.Configuration;
@@ -66,6 +67,13 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             {
                 foreach (var e in events)
                 {
+                    //restore event context so ApplicationInsights TelemetryInitializer could access it
+                    object eventContext;
+                    if (e.TryGetPropertyValue("EventContext", out eventContext))
+                    {
+                        ContextResolver.SetRequestContext(eventContext);
+                    }
+
                     if (cancellationToken.IsCancellationRequested)
                     {
                         return CompletedTask;

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/project.json
@@ -3,6 +3,7 @@
 
   "dependencies": {
     "Microsoft.ApplicationInsights": "2.1.0",
+    "Microsoft.Diagnostics.Correlation.Common": "1.0.0-preview1",
     "Microsoft.Diagnostics.EventFlow.Core": { "target": "project" },
     "NETStandard.Library": "1.6.0"
   },

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventDataExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventDataExtensions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
 
             foreach (var payload in eventData.Payload)
             {
-                traceRecord.properties.Add(payload.Key, payload.Value.ToString());
+                traceRecord.properties.Add(payload.Key, payload.Value);
             }
 
             sbEventData.records.Add(traceRecord);
@@ -105,8 +105,13 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                     metricName = metadata["metricName"],
                     time = eventData.Timestamp,
                     timeGrain = null,
-                    dimensions = null,
+                    dimensions = new Dictionary<string, object>()
                 };
+
+                foreach (var payload in eventData.Payload)
+                {
+                    metricRecord.dimensions.Add(payload.Key, payload.Value);
+                }
 
                 sbEventData.records.Add(metricRecord);
             }


### PR DESCRIPTION
This change implements event context for Trace and EventSource input - any state passed together with event to the output.
Context is captured in the input.
It's stored in the `EventData` payload.
Output implementations take care about it's format
