### PR TITLE
Make the Elasticsearch output work with Elasticsearch 5

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/project.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.0-*",
+  "version": "2.0.0-*",
 
   "dependencies": {
-    "Elasticsearch.Net": "[2.4.3, 5.0)",
+    "Elasticsearch.Net": "5.0.0",
     "Microsoft.Diagnostics.EventFlow.Core": { "target": "project" },
-    "NEST": "[2.4.3, 5.0)",
+    "NEST": "5.0.0",
     "NETStandard.Library": "1.6.0"
   },
 


### PR DESCRIPTION
1. Setting Refresh on BulkRequest is actually an anti-pattern, so I will probably apply that change to the 1.0 release as well. 
2. The plan is to release version 2.0 of the ES output Nuget based on this change. Version 1.0 Nuget will keep backward compat. with ES 2.x
