### PR TITLE
Streamline Serilog input configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you need to consume such counters, make sure the account your process runs un
 
 *Nuget package:* [**Microsoft.Diagnostics.EventFlow.Inputs.Serilog**](https://www.nuget.org/packages/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/)
 
-This input enables capturing diagnostic data created through [Serilog library](https://serilog.net/). It is designed to work with [Observable Serilog sink](https://github.com/serilog/serilog-sinks-observable). 
+This input enables capturing diagnostic data created through [Serilog library](https://serilog.net/).
 
 *Configuration example*
 The Serilog input has no configuration, other than the "type" property that specifies the type of the input (must be "Serilog"):
@@ -226,9 +226,7 @@ The Serilog input has no configuration, other than the "type" property that spec
 using System;
 using System.Linq;
 using Microsoft.Diagnostics.EventFlow;
-using Microsoft.Diagnostics.EventFlow.Inputs;
 using Serilog;
-using Serilog.Events;
 
 namespace SerilogEventFlow
 {
@@ -238,10 +236,12 @@ namespace SerilogEventFlow
         {
             using (var pipeline = DiagnosticPipelineFactory.CreatePipeline(".\\eventFlowConfig.json"))
             {
-                IObserver<LogEvent> serilogInput = pipeline.Inputs.OfType<SerilogInput>().First();
-                Log.Logger = new LoggerConfiguration().WriteTo.Observers(events => events.Subscribe(serilogInput)).CreateLogger();
+                Log.Logger = new LoggerConfiguration()
+                    .WriteTo.EventFlow(pipeline)
+                    .CreateLogger();
 
                 Log.Information("Hello from {friend} for {family}!", "SerilogInput", "EventFlow");
+                
                 Log.CloseAndFlush();
                 Console.ReadKey();
             }

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/LoggerSinkConfigurationEventFlowExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/LoggerSinkConfigurationEventFlowExtensions.cs
@@ -1,9 +1,14 @@
-﻿using Microsoft.Diagnostics.EventFlow;
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.Diagnostics.EventFlow;
 using Microsoft.Diagnostics.EventFlow.Inputs;
 using Serilog.Configuration;
 using Serilog.Debugging;
-using System;
 using System.Linq;
+using Validation;
 
 namespace Serilog
 {
@@ -24,8 +29,8 @@ namespace Serilog
         /// instead.</remarks>
         public static LoggerConfiguration EventFlow(this LoggerSinkConfiguration loggerSinkConfiguration, DiagnosticPipeline diagnosticPipeline)
         {
-            if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
-            if (diagnosticPipeline == null) throw new ArgumentNullException(nameof(diagnosticPipeline));
+            Requires.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration));
+            Requires.NotNull(diagnosticPipeline, nameof(diagnosticPipeline));
 
             var input = diagnosticPipeline.Inputs.OfType<SerilogInput>().FirstOrDefault();
 

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/LoggerSinkConfigurationEventFlowExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/LoggerSinkConfigurationEventFlowExtensions.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Diagnostics.EventFlow;
+using Microsoft.Diagnostics.EventFlow.Inputs;
+using Serilog.Configuration;
+using Serilog.Debugging;
+using System;
+using System.Linq;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Extends <see cref="LoggerSinkConfiguration"/>
+    /// </summary>
+    public static class LoggerSinkConfigurationEventFlowExtensions
+    {
+        /// <summary>
+        /// Publish Serilog events through a <see cref="DiagnosticPipeline"/>.
+        /// </summary>
+        /// <param name="loggerSinkConfiguration">The <c>WriteTo</c> object exposed by <see cref="LoggerConfiguration"/>.</param>
+        /// <param name="diagnosticPipeline">A configured <see cref="DiagnosticPipeline"/>. At least one Serilog input
+        /// must be configured for the pipeline.</param>
+        /// <returns>A <see cref="LoggerConfiguration"/> allowing configuration to continue.</returns>
+        /// <remarks>The method will select the first <see cref="SerilogInput"/> in the pipeline. If a specific input is desired instead,
+        /// this can be passed to <see cref="LoggerSinkConfiguration.Sink(Core.ILogEventSink, Events.LogEventLevel, Core.LoggingLevelSwitch)"/>
+        /// instead.</remarks>
+        public static LoggerConfiguration EventFlow(this LoggerSinkConfiguration loggerSinkConfiguration, DiagnosticPipeline diagnosticPipeline)
+        {
+            if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
+            if (diagnosticPipeline == null) throw new ArgumentNullException(nameof(diagnosticPipeline));
+
+            var input = diagnosticPipeline.Inputs.OfType<SerilogInput>().FirstOrDefault();
+
+            if (input == null)
+            {
+                SelfLog.WriteLine("{0}: A Serilog input has not been added to the diagnostic pipeline; events will not be published to EventFlow", nameof(LoggerSinkConfigurationEventFlowExtensions));
+                return loggerSinkConfiguration.Sink(new LoggerConfiguration().CreateLogger()); // A "null" sink.
+            }
+
+            return loggerSinkConfiguration.Sink(input);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInputFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInputFactory.cs
@@ -8,8 +8,12 @@ using Validation;
 
 namespace Microsoft.Diagnostics.EventFlow.Inputs
 {
+    /// <summary>
+    /// Factory for Serilog input elements.
+    /// </summary>
     public class SerilogInputFactory : IPipelineItemFactory<SerilogInput>
     {
+        /// <inheritdoc/>
         public SerilogInput CreateItem(IConfiguration configuration, IHealthReporter healthReporter)
         {
             Requires.NotNull(configuration, nameof(configuration));

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/project.json
@@ -20,7 +20,9 @@
 
   "buildOptions": {
     "keyFile": "../../PublicKey.snk",
-    "delaySign": true
+    "delaySign": true,
+    "warningsAsErrors": true,
+    "xmlDoc":  true
   },
 
   "authors": [ "Microsoft" ],

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/project.json
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/project.json
@@ -15,8 +15,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.2.0-beta2-build3300",
     "xunit.runner.visualstudio": "2.2.0-beta2-build1149",
-    "Serilog": "2.3.0",
-    "Serilog.Sinks.Observable": "2.0.1"
+    "Serilog": "2.3.0"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
This PR aligns Serilog input configuration more closely with typical Serilog syntax by adding `WriteTo.EventFlow()` and breaking the dependency on _Serilog.Sinks.Observable_:

```csharp
using System;
using System.Linq;
using Microsoft.Diagnostics.EventFlow;
using Serilog;

namespace SerilogEventFlow
{
    class Program
    {
        static void Main(string[] args)
        {
            using (var pipeline = DiagnosticPipelineFactory.CreatePipeline(".\\eventFlowConfig.json"))
            {
                Log.Logger = new LoggerConfiguration()
                    .WriteTo.EventFlow(pipeline)
                    .CreateLogger();

                Log.Information("Hello from {friend} for {family}!", "SerilogInput", "EventFlow");
                
                Log.CloseAndFlush();
                Console.ReadKey();
            }
        }
    }
}
```

Though the `WriteTo.EventFlow()` shortcut accepts a `DiagnosticPipeline` and performs the search for the first `SerilogInput` itself, it's still possible to add a specific `SerilogInput` directly by passing it through `WriteTo.Sink()`.

The PR also reverses the priority of the built-in Message and Exception properties to take precedence over any attached properties with the same name. It's not unusual for Serilog events to carry serialized message payloads (e.g. received from some kind of service bus) as `Message`, along with the typical text message.

Later in processing, it will be less surprising to get the text message in `Message` (consistently with other events) and the payload object in `Message_1` or similar. (Happy to back this out of course, but it seems like a worthwhile change to make.)

Keen for any feedback/suggestions. Cheers!