### PR TITLE
Parsing property values should not be dependent on CurrentCulture

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/CachingPropertyExpressionEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/CachingPropertyExpressionEvaluator.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Diagnostics.EventFlow.FilterEvaluators
                 object retval = null;
                 try
                 {
-                    retval = Convert.ChangeType(this.value, eventPropertyValueType, CultureInfo.CurrentCulture);
+                    retval = Convert.ChangeType(this.value, eventPropertyValueType, CultureInfo.InvariantCulture);
                 }
                 catch { }
                 return retval;


### PR DESCRIPTION
Currently multipe unit tests for filter evaluations fails on non-US culture OS because Float/Double are interpreted in CurrentCulture. Should use InvariantCulture rather than CurrentCulture as that would make interpretation of config files independent on OS regional settings.

   Microsoft.Diagnostics.EventFlow.Core.Tests (12 tests) [0:00.592] Failed: 12 tests failed
    FilterParsing (12 tests) [0:00.592] Failed: 12 tests failed
     AlternativeTests (1 test) [0:00.178] Failed: 1 test failed
      AlternativeWithCompositeTerms [0:00.113] Failed: Assert.True() Failure
     ConjunctionTests (2 tests) [0:00.069] Failed: 2 tests failed
      ConjunctionWithCompositeTerms [0:00.002] Failed: Assert.True() Failure
      ConjunctionWithPropertyExpressions [0:00.064] Failed: Assert.True() Failure
     EqualityEvaluatorTests (2 tests) [0:00.065] Failed: 2 tests failed
      DoublePropertyEquality [0:00.002] Failed: Assert.True() Failure
      FloatPropertyEquality [0:00.004] Failed: Assert.True() Failure
     GreaterOrEqualsEvaluatorTests (2 tests) [0:00.059] Failed: 2 tests failed
      DoublePropertyGreaterOrEquals [0:00.002] Failed: Assert.True() Failure
      FloatPropertyGreaterOrEquals [0:00.038] Failed: Assert.True() Failure
     GreaterThanEvaluatorTests (2 tests) [0:00.079] Failed: 2 tests failed
      DoublePropertyGreaterThan [0:00.002] Failed: Assert.True() Failure
      FloatPropertyGreaterThan [0:00.002] Failed: Assert.True() Failure
     LessOrEqualsEvaluatorTests (2 tests) [0:00.075] Failed: 2 tests failed
      DoublePropertyLessOrEquals [0:00.028] Failed: Assert.True() Failure
      FloatPropertyLessOrEquals [0:00.001] Failed: Assert.True() Failure
     LessThanEvaluatorTests (1 test) [0:00.066] Failed: 1 test failed
      DoublePropertyLessThan [0:00.008] Failed: Assert.True() Failure