### PR TITLE
Allow filters to evaluate Enum values (like LogLevel)

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/CachingPropertyExpressionEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/CachingPropertyExpressionEvaluator.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Reflection;
 
 namespace Microsoft.Diagnostics.EventFlow.FilterEvaluators
 {
@@ -84,6 +85,16 @@ namespace Microsoft.Diagnostics.EventFlow.FilterEvaluators
                     return parsedDateTimeOffsetValue;
                 }
                 else return null;
+            }
+            else if (eventPropertyValueType.GetTypeInfo().IsEnum)
+            {
+                object retval = null;
+                try
+                {
+                    retval = Enum.Parse(eventPropertyValueType, this.value);
+                }
+                catch (Exception) { }
+                return retval;
             }
             else
             {

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/EqualityEvaluatorTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/EqualityEvaluatorTests.cs
@@ -359,5 +359,22 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests.FilterParsing
             evaluator = new EqualityEvaluator("GuidProperty", "not a GUID value");
             Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
         }
+
+        [Fact]
+        public void EnumPropertyEquality()
+        {
+            var evaluator = new EqualityEvaluator("EnumProperty", "Warning");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new EqualityEvaluator("EnumProperty", "3");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new EqualityEvaluator("EnumProperty", "Error");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new EqualityEvaluator("EnumProperty", "2");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+        }
     }
 }

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/FilteringTestData.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/FilteringTestData.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests.FilterParsing
 
             eventData.Payload.Add("TwoMinutesAgoProperty", DateTime.Now - TimeSpan.FromMinutes(2));
 
+            eventData.Payload.Add("EnumProperty", LogLevel.Warning);
+
             // Special properties for regex evaluator testing
             eventData.Payload.Add("AbaShortProperty", "abaaaa");
             eventData.Payload.Add("AbaLongProperty", "abaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/GreaterOrEqualsEvaluatorTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/GreaterOrEqualsEvaluatorTests.cs
@@ -442,5 +442,28 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests.FilterParsing
             evaluator = new GreaterOrEqualsEvaluator("TwoMinutesAgoProperty", timestampString);
             Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
         }
+
+        [Fact]
+        public void EnumPropertyEquality()
+        {
+            var evaluator = new GreaterOrEqualsEvaluator("EnumProperty", "Warning");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new GreaterOrEqualsEvaluator("EnumProperty", "3");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new GreaterOrEqualsEvaluator("EnumProperty", "Informational");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new GreaterOrEqualsEvaluator("EnumProperty", "4");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new GreaterOrEqualsEvaluator("EnumProperty", "Error");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new GreaterOrEqualsEvaluator("EnumProperty", "2");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+        }
     }
 }

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/GreaterThanEvaluatorTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/GreaterThanEvaluatorTests.cs
@@ -442,5 +442,22 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests.FilterParsing
             evaluator = new GreaterThanEvaluator("TwoMinutesAgoProperty", timestampString);
             Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
         }
+
+        [Fact]
+        public void EnumPropertyEquality()
+        {
+            var evaluator = new GreaterThanEvaluator("EnumProperty", "Error");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new GreaterThanEvaluator("EnumProperty", "2");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+            
+            evaluator = new GreaterThanEvaluator("EnumProperty", "Warning");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new GreaterThanEvaluator("EnumProperty", "3");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+        }
     }
 }

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/InequalityEvaluatorTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/InequalityEvaluatorTests.cs
@@ -110,5 +110,22 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests.FilterParsing
             evaluator = new InequalityEvaluator("GuidProperty", "not a GUID value");
             Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
         }
+
+        [Fact]
+        public void EnumPropertyEquality()
+        {
+            var evaluator = new InequalityEvaluator("EnumProperty", "Warning");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new InequalityEvaluator("EnumProperty", "3");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+            
+            evaluator = new InequalityEvaluator("EnumProperty", "Error");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new InequalityEvaluator("EnumProperty", "2");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+        }
     }
 }

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/LessOrEqualsEvaluatorTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/LessOrEqualsEvaluatorTests.cs
@@ -443,5 +443,28 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests.FilterParsing
             evaluator = new LessOrEqualsEvaluator("TwoMinutesAgoProperty", timestampString);
             Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
         }
+
+        [Fact]
+        public void EnumPropertyEquality()
+        {
+            var evaluator = new LessOrEqualsEvaluator("EnumProperty", "Warning");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new LessOrEqualsEvaluator("EnumProperty", "3");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new LessOrEqualsEvaluator("EnumProperty", "Informational");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new LessOrEqualsEvaluator("EnumProperty", "4");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new LessOrEqualsEvaluator("EnumProperty", "Error");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new LessOrEqualsEvaluator("EnumProperty", "2");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+        }
     }
 }


### PR DESCRIPTION
Added value interpreter for Enum type properties (like LogLevel)

Filters can with this be expressed as:

"include": "Level == Informational"
"include": "Level != Error"
"include": "ProviderName == EventSourceName && Level == Error"
"include": "ProviderName == EventSourceName && Level <= Warning"
"include": "Level != Warning"
