### PR TITLE
Fix issue 47

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,17 @@ public static void Main(string[] args)
 }
 ```
 
+### Support for Service Fabric settings and application parameters
+Version 1.0.1 of the EventFlow Service Fabric NuGet package introduced the ability to refer to Service Fabric settings from EventFlow configuration using special syntax for values:
+
+`servicefabric:/<section-name>/<setting-name>`
+
+where `<section-name>` is the name of Service Fabric configuration section and `<setting-name>` is the name of the Service Fabric configuration setting that is providing the value for some EventFlow setting. For example:
+
+`"basicAuthenticationUserPassword": "servicefabric:/DiagnosticPipelineParameters/ElasticSearchUserPassword"`
+
+The EventFlow configuration entry above means "take the ElasticSearchUserPassword setting from DiagnosticPipelineParameters section of the Service Fabric service configuration and use its value as the value for the EventFlow basicAuthenticationUserPassword setting". As with other Service Fabric settings, the values can also be overriden by Service Fabric application parameters. For more information on this see [Manage application parameters for multiple environments](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-multiple-environment-app-configuration) topic in Service Fabric documentation.
+
 ## Logical Expressions
 The logical expression allows you to filter events based on the event properties. For example, you can have an expression like "ProviderName == MyEventProvider && EventId == 3", where you specify the event property name on the left side and the value to compare on the right side. If the value on the right side contains special characters, you can enclose it in double quotes.
 

--- a/Warsaw.sln
+++ b/Warsaw.sln
@@ -120,6 +120,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Diagnostics.Event
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Utilities", "Utilities", "{C0F892AE-D5F5-42FD-943C-6428CA252650}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests", "test\Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests\Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.xproj", "{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -328,6 +330,14 @@ Global
 		{9235A262-D532-4A06-91D4-6CF6F0BE2BCA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9235A262-D532-4A06-91D4-6CF6F0BE2BCA}.Release|x64.ActiveCfg = Release|Any CPU
 		{9235A262-D532-4A06-91D4-6CF6F0BE2BCA}.Release|x64.Build.0 = Release|Any CPU
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}.Debug|x64.Build.0 = Debug|Any CPU
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}.Release|x64.ActiveCfg = Release|Any CPU
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -358,5 +368,6 @@ Global
 		{E987F059-33CD-4F0E-8680-63C8033D54D8} = {47200F40-43E1-4B09-B803-A921FED2BF05}
 		{C81591D6-AF6B-4B55-B6EB-A5CBD9E73EDD} = {47200F40-43E1-4B09-B803-A921FED2BF05}
 		{9235A262-D532-4A06-91D4-6CF6F0BE2BCA} = {C0F892AE-D5F5-42FD-943C-6428CA252650}
+		{DDD81612-98D7-4CFC-BB69-7A2598B3AD2F} = {86A33E36-2266-4E31-8D91-1F720C9A1F27}
 	EndGlobalSection
 EndGlobal

--- a/nuspecs/ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.nuspec
+++ b/nuspecs/ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Diagnostics.EventFlow.ServiceFabric</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/diagnostics-eventflow</projectUrl>

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DiagnosticPipeline.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DiagnosticPipeline.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Diagnostics.EventFlow
                 filterTransform = new FilterAction(
                     this.GlobalFilters,
                     this.cancellationTokenSource.Token,
-                    this.pipelineConfiguration.MaxEventBatchSize,
+                    MaxNumberOfBatchesInProgress,
                     this.pipelineConfiguration.MaxConcurrency,
                     healthReporter,
                     this.OnEventsFilteredOut);

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/ServiceFabricConfigurationProvider.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/ServiceFabricConfigurationProvider.cs
@@ -1,0 +1,44 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Fabric;
+using Microsoft.Extensions.Configuration;
+using Validation;
+
+namespace Microsoft.Extensions.Configuration.ServiceFabric
+{
+    public class ServiceFabricConfigurationProvider: ConfigurationProvider
+    {
+        public const string DefaultConfigurationPackageName = "Config";
+
+        private string configurationPackageName;
+
+        public ServiceFabricConfigurationProvider(string configurationPackageName = DefaultConfigurationPackageName)
+        {
+            Requires.NotNullOrEmpty(configurationPackageName, nameof(configurationPackageName));
+
+            this.configurationPackageName = configurationPackageName;
+        }
+
+        public override void Load()
+        {
+            // TODO: react to configuration changes by listening to ConfiugrationPackageActivationContext.ConfigurationPackageModifiedEvent
+
+            CodePackageActivationContext activationContext = FabricRuntime.GetActivationContext();
+            ConfigurationPackage configPackage = activationContext.GetConfigurationPackageObject(this.configurationPackageName);
+            foreach (var configurationSection in configPackage.Settings.Sections)
+            {
+                foreach(var property in configurationSection.Parameters)
+                {
+                    // We omit encrypted values due to security concerns--if you need them, use Service Fabric APIs to access them
+                    if (!property.IsEncrypted)
+                    {
+                        Data[ConfigurationPath.Combine(configurationSection.Name, property.Name)] = property.Value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/ServiceFabricConfigurationSource.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/ServiceFabricConfigurationSource.cs
@@ -1,0 +1,25 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.Configuration.ServiceFabric
+{
+    public class ServiceFabricConfigurationSource : IConfigurationSource
+    {
+        public string ConfigurationPackageName { get; set; }
+
+        public ServiceFabricConfigurationSource()
+        {
+            this.ConfigurationPackageName = ServiceFabricConfigurationProvider.DefaultConfigurationPackageName;
+        }
+
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return new ServiceFabricConfigurationProvider(this.ConfigurationPackageName);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/ServiceFabricExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/ServiceFabricExtensions.cs
@@ -1,0 +1,26 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Microsoft.Extensions.Configuration.ServiceFabric;
+
+namespace Microsoft.Extensions.Configuration
+{
+    public static class ServiceFabricExtensions
+    {
+        public static IConfigurationBuilder AddServiceFabric(this IConfigurationBuilder builder)
+            => builder.Add(new ServiceFabricConfigurationSource());
+
+        public static IConfigurationBuilder AddServiceFabric(this IConfigurationBuilder builder, string configurationPackageName)
+            => builder.Add(new ServiceFabricConfigurationSource { ConfigurationPackageName = configurationPackageName });
+
+        public static IConfigurationBuilder AddServiceFabric(this IConfigurationBuilder builder, Action<ServiceFabricConfigurationSource> configureSource)
+        {
+            var source = new ServiceFabricConfigurationSource();
+            configureSource(source);
+            return builder.Add(source);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.Diagnostics.EventFlow.ServiceFabric")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e63c9dcd-042f-4608-b76b-9506860bf543")]
+
+[assembly: InternalsVisibleTo("Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
@@ -4,8 +4,11 @@
 // ------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Fabric;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Diagnostics.EventFlow;
 using Microsoft.Extensions.Configuration;
 using Validation;
@@ -14,6 +17,9 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
 {
     public static class ServiceFabricDiagnosticPipelineFactory
     {
+        public static readonly string ConfigurationPackageName = "Config";
+        public static readonly string FabricConfigurationValueReference = @"servicefabric:/(?<section>\w+)/(?<name>\w+)";
+
         public static DiagnosticPipeline CreatePipeline(string healthEntityName, string configurationFileName = "eventFlowConfig.json")
         {
             // TODO: dynamically re-configure the pipeline when configuration changes, without stopping the service
@@ -23,7 +29,7 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
             var healthReporter = new ServiceFabricHealthReporter(healthEntityName);
 
             CodePackageActivationContext activationContext = FabricRuntime.GetActivationContext();
-            ConfigurationPackage configPackage = activationContext.GetConfigurationPackageObject("Config");
+            ConfigurationPackage configPackage = activationContext.GetConfigurationPackageObject(ConfigurationPackageName);
             string configFilePath = Path.Combine(configPackage.Path, configurationFileName);
             if (!File.Exists(configFilePath))
             {
@@ -34,8 +40,53 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
 
             ConfigurationBuilder configBuilder = new ConfigurationBuilder();
             configBuilder.AddJsonFile(configFilePath);
-            IConfigurationRoot configurationRoot = configBuilder.Build();
+            configBuilder.AddServiceFabric(ConfigurationPackageName);
+            IConfigurationRoot configurationRoot = configBuilder.Build().ApplyFabricConfigurationOverrides(healthReporter);
+
             return DiagnosticPipelineFactory.CreatePipeline(configurationRoot, new ServiceFabricHealthReporter(healthEntityName));
+        }
+
+        internal static IConfigurationRoot ApplyFabricConfigurationOverrides(this IConfigurationRoot configurationRoot, IHealthReporter healthReporter)
+        {
+            Debug.Assert(configurationRoot != null);
+            Debug.Assert(healthReporter != null);
+
+            Regex fabricValueReferenceRegex = new Regex(FabricConfigurationValueReference, RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+
+            // Use ToList() to ensure that configuration is fully enumerated before starting to modify it.
+            foreach (var kvp in configurationRoot.AsEnumerable().ToList())
+            {
+                if (kvp.Value == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    Match valueReferenceMatch = fabricValueReferenceRegex.Match(kvp.Value);
+                    if (valueReferenceMatch.Success)
+                    {
+                        string valueReferencePath = ConfigurationPath.Combine(valueReferenceMatch.Groups["section"].Value, valueReferenceMatch.Groups["name"].Value);
+                        string newValue = configurationRoot[valueReferencePath];
+                        if (string.IsNullOrEmpty(newValue))
+                        {
+                            healthReporter.ReportWarning(
+                                $"Configuration value reference '{kvp.Value}' was encountered but no corresponding configuration value was found using path '{valueReferencePath}'", 
+                                EventFlowContextIdentifiers.Configuration);
+                        }
+                        else
+                        {
+                            configurationRoot[kvp.Key] = newValue;
+                        }
+                    }
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    continue;
+                }
+            }
+
+            return configurationRoot;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/project.json
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/project.json
@@ -1,9 +1,11 @@
 ﻿{
-  "version": "1.0.0-*",
+  "version": "1.0.1-*",
 
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "Microsoft.ServiceFabric": "5.1.163",
+    "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
+    "Microsoft.Extensions.Configuration": "1.0.0",
     "Microsoft.Diagnostics.EventFlow.Core": { "target": "project" }
   },
 

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.xproj
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="..\..\targets\DotNet\Microsoft.DotNet.Props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>ddd81612-98d7-4cfc-bb69-7a2598b3ad2f</ProjectGuid>
+    <RootNamespace>Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="..\..\targets\DotNet\Microsoft.DotNet.targets" />
+</Project>

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/ServiceFabricTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/ServiceFabricTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests
+{
+    public class ServiceFabricTests
+    {
+        [Fact]
+        public void ConfigurationIsNotChangedIfNoValueReferencesExist()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var configurationSource = new Dictionary<string, string>()
+            {
+                ["alpha"] = "Alpha",
+                ["bravo:charlie"] = "BravoCharlie"
+            };
+
+            IConfigurationRoot configuration = (new ConfigurationBuilder()).AddInMemoryCollection(configurationSource).Build();
+            ServiceFabricDiagnosticPipelineFactory.ApplyFabricConfigurationOverrides(configuration, healthReporterMock.Object);
+
+            string verificationError;
+            bool isOK = VerifyConfguration(configuration.AsEnumerable(), configurationSource, out verificationError);
+            Assert.True(isOK, verificationError);
+            healthReporterMock.Verify(o => o.ReportProblem(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            healthReporterMock.Verify(o => o.ReportWarning(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public void ConfigurationIsNotChangedIfValueReferenceNotResolved()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var configurationSource = new Dictionary<string, string>()
+            {
+                ["alpha"] = "Alpha",
+                ["bravo:charlie"] = "BravoCharlie",
+                ["delta"] = "servicefabric:/bravo/foxtrot"
+            };
+
+            IConfigurationRoot configuration = (new ConfigurationBuilder()).AddInMemoryCollection(configurationSource).Build();
+            ServiceFabricDiagnosticPipelineFactory.ApplyFabricConfigurationOverrides(configuration, healthReporterMock.Object);
+
+            string verificationError;
+            bool isOK = VerifyConfguration(configuration.AsEnumerable(), configurationSource, out verificationError);
+            Assert.True(isOK, verificationError);
+
+            healthReporterMock.Verify(o => o.ReportWarning(
+                        It.Is<string>(s => s.Contains("no corresponding configuration value was found")),
+                        It.Is<string>(s => s == EventFlowContextIdentifiers.Configuration)),
+                    Times.Exactly(1));
+        }
+
+        [Fact]
+        public void ConfigurationUpdatedWithValueReferences()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var configurationSource = new Dictionary<string, string>()
+            {
+                ["alpha"] = "Alpha",
+                ["bravo:charlie"] = "BravoCharlie",
+                ["delta"] = "servicefabric:/bravo/charlie"
+            };
+
+            IConfigurationRoot configuration = (new ConfigurationBuilder()).AddInMemoryCollection(configurationSource).Build();
+            ServiceFabricDiagnosticPipelineFactory.ApplyFabricConfigurationOverrides(configuration, healthReporterMock.Object);
+            healthReporterMock.Verify(o => o.ReportProblem(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            healthReporterMock.Verify(o => o.ReportWarning(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+
+            string verificationError;
+            bool isOK = VerifyConfguration(configuration.AsEnumerable(), configurationSource, out verificationError);
+            Assert.False(isOK, verificationError);
+
+            configurationSource["delta"] = "BravoCharlie";
+            isOK = VerifyConfguration(configuration.AsEnumerable(), configurationSource, out verificationError);
+            Assert.True(isOK, verificationError);
+        }
+
+        private bool VerifyConfguration<TKey, TValue>(
+            IEnumerable<KeyValuePair<TKey, TValue>> configuration,
+            IDictionary<TKey, TValue> expected,
+            out string verificationError,
+            IEqualityComparer<TValue> valueComparer = null)
+        {
+            verificationError = string.Empty;
+
+            var keyComparer = EqualityComparer<TKey>.Default;
+            valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
+
+            foreach (var kvp in expected)
+            {
+                KeyValuePair<TKey, TValue>? correspondingPair = configuration.Where(otherKvp => keyComparer.Equals(otherKvp.Key, kvp.Key))
+                    .Cast<KeyValuePair<TKey, TValue>?>()
+                    .FirstOrDefault();
+
+                if (correspondingPair == null)
+                {
+                    verificationError = $"Configuration is missing expected key '{kvp.Key}'";
+                    return false;
+                }
+
+                if (!valueComparer.Equals(kvp.Value, correspondingPair.Value.Value))
+                {
+                    verificationError = $"The value for key '{kvp.Key}' was expected to be '{kvp.Value}' but instead it is '{correspondingPair.Value.Value}')";
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/project.json
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/project.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "keyFile": "../../PublicKey.snk",
+    "delaySign": true
+  },
+  "dependencies": {
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "Microsoft.Diagnostics.EventFlow.Core": { "target": "project" },
+    "Microsoft.Diagnostics.EventFlow.ServiceFabric": { "target": "project" },
+    "Moq": "4.6.36-alpha",
+    "System.ComponentModel.Primitives": "4.1.0",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
+    "xunit": "2.2.0-beta2-build3300",
+    "xunit.runner.visualstudio": "2.2.0-beta2-build1149"
+  },
+  "testRunner": "xunit",
+  "frameworks": {
+    "net46": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes issue https://github.com/Azure/diagnostics-eventflow/issues/47 by adding ability to refer to Service Fabric settings and application parameters from EventFlow configuration