### PR TITLE
Include MessageTemplate in events from the Serilog input

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInput.cs
@@ -96,6 +96,9 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
                 healthReporter.ReportWarning($"{nameof(SerilogInput)}: event message could not be rendered{Environment.NewLine}{e.ToString()}");
             }
 
+            // MessageTemplate is always present on Serilog events
+            eventData.AddPayloadProperty("MessageTemplate", logEvent.MessageTemplate.Text, healthReporter, nameof(SerilogInput));
+
             foreach (var property in logEvent.Properties.Where(property => property.Value != null))
             {
                 try

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/SerilogInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/SerilogInputTests.cs
@@ -83,6 +83,27 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
         }
 
         [Fact]
+        public void ReportsMessageTemplate()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var observer = new Mock<IObserver<EventData>>();
+            using (var serilogInput = new SerilogInput(healthReporterMock.Object))
+            using (serilogInput.Subscribe(observer.Object))
+            {
+                var logger = new LoggerConfiguration().WriteTo.Sink(serilogInput).CreateLogger();
+
+                string messageTemplate = "Hello, {Name}!";
+                logger.Information(messageTemplate, "World");
+
+                observer.Verify(s => s.OnNext(It.Is<EventData>(data =>
+                       data.Payload["Message"].Equals("Hello, World!")
+                    && data.Level == LogLevel.Informational
+                    && data.Payload["MessageTemplate"].Equals(messageTemplate)
+                )));
+            }
+        }
+
+        [Fact]
         public void ReportsLevelsProperly()
         {
             var healthReporterMock = new Mock<IHealthReporter>();


### PR DESCRIPTION
The `MessageTemplate` is used in lieu of an explicit "event type" by Serilog and many of its sinks. This PR attaches this property to events from the input.

Fixes #63. 
