### PR TITLE
Add new metadata types

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/DependencyData.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/DependencyData.cs
@@ -1,0 +1,73 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow.Metadata
+{
+    public class DependencyData: NetworkCallData
+    {
+        public static readonly string DependencyMetadataKind = "dependency";        
+        public static readonly string TargetPropertyMoniker = "targetProperty";
+        public static readonly string DependecyTypeMoniker = "dependencyType";
+        
+        public string Target { get; private set; }
+        public string DependencyType { get; private set; }
+
+        // Ensure that DependencyData can only be created using TryGetDependencyData() method
+        private DependencyData() { }
+
+        public static DataRetrievalResult TryGetData(
+            EventData eventData,
+            EventMetadata dependencyMetadata,
+            out DependencyData dependency)
+        {
+            Requires.NotNull(eventData, nameof(eventData));
+            Requires.NotNull(dependencyMetadata, nameof(dependencyMetadata));
+            dependency = null;
+
+            if (!DependencyMetadataKind.Equals(dependencyMetadata.MetadataType, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return DataRetrievalResult.InvalidMetadataType(dependencyMetadata.MetadataType, DependencyMetadataKind);
+            }
+
+            DataRetrievalResult result = GetSuccessValue(eventData, dependencyMetadata, out bool? success);
+            if (result.Status != DataRetrievalStatus.Success)
+            {
+                return result;
+            }
+
+            result = GetDurationValue(eventData, dependencyMetadata, out TimeSpan? duration);
+            if (result.Status != DataRetrievalStatus.Success)
+            {
+                return result;
+            }
+
+            result = GetResponseCodeValue(eventData, dependencyMetadata, out string responseCode);
+            if (result.Status != DataRetrievalStatus.Success)
+            {
+                return result;
+            }
+
+            result = dependencyMetadata.GetEventPropertyValue(eventData, TargetPropertyMoniker, out string target);
+            if (result.Status != DataRetrievalStatus.Success)
+            {
+                return result;
+            }
+
+            string dependencyType = dependencyMetadata[DependecyTypeMoniker];
+
+            dependency = new DependencyData();
+            dependency.IsSuccess = success;
+            dependency.Duration = duration;
+            dependency.ResponseCode = responseCode;
+            dependency.Target = target;
+            dependency.DependencyType = dependencyType;
+
+            return DataRetrievalResult.Success;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/DurationUnit.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/DurationUnit.cs
@@ -1,0 +1,16 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Diagnostics.EventFlow.Metadata
+{
+    public enum DurationUnit
+    {
+        TimeSpan,
+        Milliseconds,
+        Seconds,
+        Minutes,
+        Hours
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/ExceptionData.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/ExceptionData.cs
@@ -1,0 +1,47 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow.Metadata
+{
+    public class ExceptionData
+    {
+        public static readonly string ExceptionMetadataKind = "exception";
+        public static readonly string ExceptionPropertyMoniker = "exceptionProperty";
+
+        public Exception Exception { get; private set; }
+
+        private ExceptionData(Exception e)
+        {
+            Debug.Assert(e != null);
+            this.Exception = e;
+        }
+
+        public static DataRetrievalResult TryGetData(
+            EventData eventData,
+            EventMetadata exceptionMetadata,
+            out ExceptionData exceptionData)
+        {
+            Requires.NotNull(eventData, nameof(eventData));
+            Requires.NotNull(exceptionMetadata, nameof(exceptionMetadata));
+            exceptionData = null;
+
+            if (!ExceptionMetadataKind.Equals(exceptionMetadata.MetadataType, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return DataRetrievalResult.InvalidMetadataType(exceptionMetadata.MetadataType, ExceptionMetadataKind);
+            }
+
+            DataRetrievalResult result = exceptionMetadata.GetEventPropertyValue(eventData, ExceptionPropertyMoniker, out Exception e);
+            if (result.Status == DataRetrievalStatus.Success)
+            {
+                exceptionData = new ExceptionData(e);
+            }
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/MetricData.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/MetricData.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Diagnostics.EventFlow.Metadata
             Requires.NotNull(metricMetadata, nameof(metricMetadata));
             metric = null;
 
+            if (!MetricMetadataKind.Equals(metricMetadata.MetadataType, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return DataRetrievalResult.InvalidMetadataType(metricMetadata.MetadataType, MetricMetadataKind);
+            }
+
             string metricName = metricMetadata[MetricNameMoniker];
             if (string.IsNullOrEmpty(metricName))
             {
@@ -59,7 +64,8 @@ namespace Microsoft.Diagnostics.EventFlow.Metadata
             metric = new MetricData();
             metric.MetricName = metricName;
             metric.Value = value;
-            return DataRetrievalResult.Success();
+
+            return DataRetrievalResult.Success;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/NetworkCallData.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/NetworkCallData.cs
@@ -1,0 +1,119 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Diagnostics.EventFlow.Metadata
+{
+    public abstract class NetworkCallData
+    {
+        public static readonly string IsSuccessPropertyMoniker = "isSuccessProperty";
+        public static readonly string DurationPropertyMoniker = "durationProperty";
+        public static readonly string DurationUnitMoniker = "durationUnit";
+        public static readonly string ResponseCodePropertyMoniker = "responseCodeProperty";
+
+        public TimeSpan? Duration { get; protected set; }
+        public bool? IsSuccess { get; protected set; }
+        public string ResponseCode { get; protected set; }
+
+        protected static DataRetrievalResult GetSuccessValue(EventData eventData, EventMetadata networkCallMetadata, out bool? success)
+        {
+            success = null;
+
+            string isSuccessProperty = networkCallMetadata[IsSuccessPropertyMoniker];
+            if (!string.IsNullOrWhiteSpace(isSuccessProperty))
+            {
+                bool? localSuccessVal = null;
+                if (!eventData.GetValueFromPayload<bool>(isSuccessProperty, (v) => localSuccessVal = v))
+                {
+                    return DataRetrievalResult.DataMissingOrInvalid(isSuccessProperty);
+                }
+                else
+                {
+                    success = localSuccessVal;
+                }
+            }
+
+            return DataRetrievalResult.Success;
+        }
+
+        protected static DataRetrievalResult GetDurationValue(EventData eventData, EventMetadata networkCallMetadata, out TimeSpan? duration)
+        {
+            duration = null;
+            string durationProperty = networkCallMetadata[DurationPropertyMoniker];
+            if (!string.IsNullOrWhiteSpace(durationProperty))
+            {
+                DurationUnit durationUnit;
+                string durationUnitOverride = networkCallMetadata[DurationUnitMoniker];
+                if (string.IsNullOrEmpty(durationUnitOverride) || !Enum.TryParse<DurationUnit>(durationUnitOverride, ignoreCase: true, result: out durationUnit))
+                {
+                    // By default we assume duration is stored as a double value representing milliseconds
+                    durationUnit = DurationUnit.Milliseconds;
+                }
+
+                if (durationUnit != DurationUnit.TimeSpan)
+                {
+                    double tempDuration = 0.0;
+                    if (!eventData.GetValueFromPayload<double>(durationProperty, (v) => tempDuration = v))
+                    {
+                        return DataRetrievalResult.DataMissingOrInvalid(durationProperty);
+                    }
+                    duration = ToTimeSpan(tempDuration, durationUnit);
+                }
+                else
+                {
+                    TimeSpan? localDurationVal = null;
+                    if (!eventData.GetValueFromPayload<TimeSpan>(durationProperty, (v) => localDurationVal = v))
+                    {
+                        return DataRetrievalResult.DataMissingOrInvalid(durationProperty);
+                    }
+                    else
+                    {
+                        duration = localDurationVal;
+                    }
+                }
+            }
+
+            return DataRetrievalResult.Success;
+        }
+
+        protected static DataRetrievalResult GetResponseCodeValue(EventData eventData, EventMetadata networkCallMetadata, out string responseCode)
+        {
+            responseCode = null;
+            string responseCodeProperty = networkCallMetadata[ResponseCodePropertyMoniker];
+            if (!string.IsNullOrWhiteSpace(responseCodeProperty))
+            {
+                string localResponseCodeVal = null;
+                if (!eventData.GetValueFromPayload<string>(responseCodeProperty, (v) => localResponseCodeVal = v))
+                {
+                    return DataRetrievalResult.DataMissingOrInvalid(responseCodeProperty);
+                }
+                else
+                {
+                    responseCode = localResponseCodeVal;
+                }
+            }
+
+            return DataRetrievalResult.Success;
+        }
+
+        private static TimeSpan ToTimeSpan(double value, DurationUnit durationUnit)
+        {
+            switch (durationUnit)
+            {
+                case DurationUnit.Milliseconds:
+                    return TimeSpan.FromMilliseconds(value);
+                case DurationUnit.Seconds:
+                    return TimeSpan.FromSeconds(value);
+                case DurationUnit.Minutes:
+                    return TimeSpan.FromMinutes(value);
+                case DurationUnit.Hours:
+                    return TimeSpan.FromHours(value);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(durationUnit), "Error during request data extraction: unexpected durationUnit value");
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Metadata/EventTelemetryData.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Metadata/EventTelemetryData.cs
@@ -1,0 +1,54 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+
+using Validation;
+using Microsoft.Diagnostics.EventFlow.Metadata;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights
+{
+    /// <summary>
+    /// Object representing data associated with "Event" telemetry type in Application Insights.
+    /// </summary>
+    internal class EventTelemetryData
+    {
+        internal static readonly string EventMetadataKind = "ai_event";
+        internal static readonly string EventNamePropertyMoniker = "eventNameProperty";
+        internal static readonly string EventNameMoniker = "eventName";
+
+        public string Name { get; private set; }
+
+        private EventTelemetryData() { }
+
+        public static DataRetrievalResult TryGetData(
+            EventData eventData,
+            EventMetadata eventTelemetryMetadata,
+            out EventTelemetryData eventTelemetryData)
+        {
+            Requires.NotNull(eventData, nameof(eventData));
+            Requires.NotNull(eventTelemetryMetadata, nameof(eventTelemetryMetadata));
+            eventTelemetryData = null;
+
+            if (!EventMetadataKind.Equals(eventTelemetryMetadata.MetadataType, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return DataRetrievalResult.InvalidMetadataType(eventTelemetryMetadata.MetadataType, EventMetadataKind);
+            }
+
+            string eventName = eventTelemetryMetadata[EventNameMoniker];
+            if (string.IsNullOrWhiteSpace(eventName))
+            {
+                DataRetrievalResult result = eventTelemetryMetadata.GetEventPropertyValue(eventData, EventNamePropertyMoniker, out eventName);
+                if (result.Status != DataRetrievalStatus.Success)
+                {
+                    return result;
+                }
+            }
+
+            eventTelemetryData = new EventTelemetryData();
+            eventTelemetryData.Name = eventName;
+            return DataRetrievalResult.Success;
+        }
+    }
+}

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/MetadataTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/MetadataTests.cs
@@ -1,0 +1,285 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using Xunit;
+using Microsoft.Diagnostics.EventFlow.Metadata;
+using System;
+
+namespace Microsoft.Diagnostics.EventFlow.Core.Tests
+
+{
+    public class MetadataTests
+    {
+        private static readonly int DoublePrecisionTolerance = 5; // Five decimal places
+
+        [Fact]
+        public void MetricDataReadSuccessfully()
+        {
+            EventData eventData = new EventData();
+            eventData.Payload.Add("metricValue", 17.4);
+
+            EventMetadata metricMetadata = new EventMetadata(MetricData.MetricMetadataKind);
+            metricMetadata.Properties.Add(MetricData.MetricNameMoniker, "SomeMetric");
+            metricMetadata.Properties.Add(MetricData.MetricValueMoniker, "33.5");
+
+            // Fixed-value metric
+            var result = MetricData.TryGetData(eventData, metricMetadata, out MetricData md);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal(33.5, md.Value, DoublePrecisionTolerance);
+            Assert.Equal("SomeMetric", md.MetricName);
+
+            // Value read from event properties
+            metricMetadata.Properties.Remove(MetricData.MetricValueMoniker);
+            metricMetadata.Properties.Add(MetricData.MetricValuePropertyMoniker, "metricValue");
+            result = MetricData.TryGetData(eventData, metricMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal(17.4, md.Value, DoublePrecisionTolerance);
+
+            // Able to convert event property value to a double as needed
+            eventData.Payload["metricValue"] = "3.14";
+            result = MetricData.TryGetData(eventData, metricMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal(3.14, md.Value, DoublePrecisionTolerance);
+        }
+
+        [Fact]
+        public void MetricDataExpectedReadFailures()
+        {
+            EventData eventData = new EventData();
+
+            // Invalid metadata type
+            EventMetadata metricMetadata = new EventMetadata("someOtherType");
+
+            var result = MetricData.TryGetData(eventData, metricMetadata, out MetricData md);
+            Assert.Equal(DataRetrievalStatus.InvalidMetadataType, result.Status);
+
+            // Missing metric name property
+            metricMetadata = new EventMetadata(MetricData.MetricMetadataKind);
+            result = MetricData.TryGetData(eventData, metricMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.MetadataPropertyMissing, result.Status);
+            Assert.Contains("Expected property 'metricName'", result.Message);
+
+            // No metricValue or metricValueProperty on the metadata
+            metricMetadata.Properties.Add(MetricData.MetricNameMoniker, "SomeMetric");
+            result = MetricData.TryGetData(eventData, metricMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.MetadataPropertyMissing, result.Status);
+            Assert.Contains("Expected property 'metricValue'", result.Message);
+
+            // metricValue cannot be parsed
+            metricMetadata.Properties.Add("metricValue", "not_a_number");
+            result = MetricData.TryGetData(eventData, metricMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.InvalidMetadataValue, result.Status);
+
+            // metricValueProperty points to a property that does not exist
+            metricMetadata.Properties.Remove("metricValue");
+            metricMetadata.Properties.Add("metricValueProperty", "value");
+            result = MetricData.TryGetData(eventData, metricMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+
+            // metricValueProperty points to a property that does not containa a value that can be parsed as double
+            eventData.Payload.Add("value", "not-a-number");
+            result = MetricData.TryGetData(eventData, metricMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+        }
+
+        [Fact]
+        public void RequestDataReadSuccessfully()
+        {
+            EventData eventData = new EventData();
+            eventData.Payload.Add("requestName", "GetCountOfStuff");
+            eventData.Payload.Add("isSuccess", true);
+            eventData.Payload.Add("responseCode", "200 OK");
+
+            EventMetadata requestMetadata = new EventMetadata("request");
+            requestMetadata.Properties.Add("requestNameProperty", "requestName");
+            requestMetadata.Properties.Add("isSuccessProperty", "isSuccess");
+            requestMetadata.Properties.Add("responseCodeProperty", "responseCode");
+            requestMetadata.Properties.Add("durationProperty", "duration");
+
+            // Duration is milliseconds, seconds, minutes, hours, timespan
+            eventData.Payload.Add("duration", 34.7);
+            requestMetadata.Properties.Add("durationUnit", "milliseconds");
+            var result = RequestData.TryGetData(eventData, requestMetadata, out RequestData rd);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal("GetCountOfStuff", rd.RequestName);
+            Assert.True(rd.IsSuccess);
+            Assert.Equal("200 OK", rd.ResponseCode);
+            // Note the TimeSpan.FromMilliseconds will round to the nearest millisecond
+            Assert.Equal(35, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
+
+            requestMetadata.Properties["durationUnit"] = "seconds";
+            result = RequestData.TryGetData(eventData, requestMetadata, out rd);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal(34.7, rd.Duration.Value.TotalSeconds, DoublePrecisionTolerance);
+
+            requestMetadata.Properties["durationUnit"] = "minutes";
+            result = RequestData.TryGetData(eventData, requestMetadata, out rd);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal(34.7, rd.Duration.Value.TotalMinutes, DoublePrecisionTolerance);
+
+            requestMetadata.Properties["durationUnit"] = "hours";
+            result = RequestData.TryGetData(eventData, requestMetadata, out rd);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal(34.7, rd.Duration.Value.TotalHours, DoublePrecisionTolerance);
+
+            requestMetadata.Properties["durationUnit"] = "TimeSpan";
+            eventData.Payload["duration"] = TimeSpan.FromMilliseconds(124);
+            result = RequestData.TryGetData(eventData, requestMetadata, out rd);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal(124, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
+
+            // Duration is not specified--default to milliseconds
+            requestMetadata.Properties.Remove("durationUnit");
+            eventData.Payload["duration"] = 65.7;
+            result = RequestData.TryGetData(eventData, requestMetadata, out rd);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal(66, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
+        }
+
+        [Fact]
+        public void RequestDataExpectedReadFailure()
+        {
+            // Invalid metadata type
+            EventMetadata requestMetadata = new EventMetadata("someOtherType");
+            EventData eventData = new EventData();
+
+            var result = RequestData.TryGetData(eventData, requestMetadata, out RequestData md);
+            Assert.Equal(DataRetrievalStatus.InvalidMetadataType, result.Status);
+
+            requestMetadata = new EventMetadata("request");
+            requestMetadata.Properties.Add("requestNameProperty", "requestName");
+            requestMetadata.Properties.Add("isSuccessProperty", "isSuccess");
+            requestMetadata.Properties.Add("responseCodeProperty", "responseCode");
+            requestMetadata.Properties.Add("durationProperty", "duration");
+
+            // isSuccessProperty points to non-existing property
+            result = RequestData.TryGetData(eventData, requestMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+            Assert.Contains("The expected event property 'isSuccess'", result.Message);
+
+            eventData.Payload.Add("isSuccess", false);
+
+            // durationProperty points to non-existing property
+            result = RequestData.TryGetData(eventData, requestMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+            Assert.Contains("The expected event property 'duration'", result.Message);
+
+            // duration is not a number
+            eventData.Payload.Add("duration", "not-a-number");
+            result = RequestData.TryGetData(eventData, requestMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+            Assert.Contains("The expected event property 'duration'", result.Message);
+
+            eventData.Payload["duration"] = 15.7;
+
+            // responseCodeProperty points to non-existing property
+            result = RequestData.TryGetData(eventData, requestMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+            Assert.Contains("The expected event property 'responseCode'", result.Message);
+
+            eventData.Payload.Add("responseCode", "401 Not Found");
+
+            // Just make sure that after addressing all the issues you can read all the data successfully
+            result = RequestData.TryGetData(eventData, requestMetadata, out md);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+        }
+
+        [Fact]
+        public void DependencyDataReadSuccessfully()
+        {
+            // The handling of isSuccess, duration and response code is tested fairly thoroughly by Request tests,
+            // so here wie will just focus on Dependency-specific properties: target and dependency type.
+            EventData eventData = new EventData();
+            eventData.Payload.Add("isSuccess", true);
+            eventData.Payload.Add("responseCode", "200 OK");
+            eventData.Payload.Add("duration", 212);
+            eventData.Payload.Add("targetServiceUrl", "http://customerdata");
+
+            EventMetadata dependencyMetadata = new EventMetadata("dependency");
+            dependencyMetadata.Properties.Add("isSuccessProperty", "isSuccess");
+            dependencyMetadata.Properties.Add("responseCodeProperty", "responseCode");
+            dependencyMetadata.Properties.Add("durationProperty", "duration");
+            dependencyMetadata.Properties.Add("targetProperty", "targetServiceUrl");
+            dependencyMetadata.Properties.Add("dependencyType", "CustomerDataService");
+
+            var result = DependencyData.TryGetData(eventData, dependencyMetadata, out DependencyData dd);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.True(dd.IsSuccess);
+            Assert.Equal("200 OK", dd.ResponseCode);
+            Assert.Equal(212, dd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
+            Assert.Equal("http://customerdata", dd.Target);
+            Assert.Equal("CustomerDataService", dd.DependencyType);
+        }
+
+        [Fact]
+        public void DependencyDataExpectedReadFailure()
+        {
+            // The handling of isSuccess, duration and response code is tested fairly thoroughly by Request tests,
+            // so here wie will just focus on Dependency-specific properties: target and dependency type.
+
+            // Target property points to non-existent property
+            EventData eventData = new EventData();
+
+            EventMetadata dependencyMetadata = new EventMetadata("dependency");
+            dependencyMetadata.Properties.Add("targetProperty", "targetServiceUrl");
+
+            var result = DependencyData.TryGetData(eventData, dependencyMetadata, out DependencyData dd);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+            Assert.Contains("The expected event property 'targetServiceUrl'", result.Message);
+
+            // Just make sure that after addressing all the issues you can read all the data successfully
+            eventData.Payload.Add("targetServiceUrl", "http://customerdata");
+            result = DependencyData.TryGetData(eventData, dependencyMetadata, out dd);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+        }
+
+        [Fact]
+        public void ExceptionDataReadSuccessfully()
+        {
+            EventData eventData = new EventData();
+
+            try
+            {
+                throw new Exception("Oops!");
+            }
+            catch (Exception e)
+            {
+                eventData.Payload.Add("exception", e);
+            }
+
+            EventMetadata exceptionMetadata = new EventMetadata("exception");
+            exceptionMetadata.Properties.Add("exceptionProperty", "exception");
+
+            var result = ExceptionData.TryGetData(eventData, exceptionMetadata, out ExceptionData exceptionData);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+            Assert.Equal("Oops!", exceptionData.Exception.Message);
+        }
+
+        [Fact]
+        public void ExceptionDataExpectedReadFailure()
+        {
+            // exceptionProperty points to non-existent property
+            EventData eventData = new EventData();
+
+            EventMetadata exceptionMetadata = new EventMetadata("exception");
+            exceptionMetadata.Properties.Add("exceptionProperty", "exception");
+
+            var result = ExceptionData.TryGetData(eventData, exceptionMetadata, out ExceptionData exceptionData);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+            Assert.Contains("The expected event property 'exception'", result.Message);
+
+            // exceptionProperty does not contain and Exception object
+            eventData.Payload.Add("exception", Guid.NewGuid());
+            result = ExceptionData.TryGetData(eventData, exceptionMetadata, out exceptionData);
+            Assert.Equal(DataRetrievalStatus.DataMissingOrInvalid, result.Status);
+            Assert.Contains("The expected event property 'exception'", result.Message);
+
+            // Just make sure that after addressing all the issues you can read all the data successfully
+            eventData.Payload["exception"] = new Exception();
+            result = ExceptionData.TryGetData(eventData, exceptionMetadata, out exceptionData);
+            Assert.Equal(DataRetrievalStatus.Success, result.Status);
+        }
+    }
+}


### PR DESCRIPTION
1. Add request and exception standard metadata
2. Add "event" metadata (ApplicationInsights-specific)
3. Add support for request and exception metadata to ApplicationInsights output and Elasticsearch output

This resolves issue https://github.com/Azure/diagnostics-eventflow/issues/48

Documentation update will be handled as a separate change