### PR TITLE
Better Service Fabric configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,8 @@ The `ServiceFabricDiagnosticPipelineFactory` is a replacement for the standard `
 | Parameter | Default Value | Description |
 | :-------- | :-------------- | :---------- |
 | `healthEntityName` | (none) | The name of the health entity that will be used to report EventFlow pipeline health to Service Fabric. Usually it is set to a value that helps you identify the service using the pipeline, for example "MyApplication-MyService-DiagnosticsPipeline". |
-| `configurationFileName` | "eventFlowConfig.json" | The name of the configuration file that contains pipeline configuration. The file is expected to be part of the (Service Fabric) service configuration package.| 
+| `configurationFileName` | "eventFlowConfig.json" | The name of the configuration file that contains pipeline configuration. The file is expected to be part of a (Service Fabric) service configuration package.| 
+| `configurationPackageName` | "Config" | The name of the Service Fabric configuration package that contains the pipeline configuration file.|
 
 The recommended place to create the diagnostic pipeline is in the service `Main()` method:
 

--- a/nuspecs/ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.nuspec
+++ b/nuspecs/ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.Diagnostics.EventFlow.ServiceFabric</id>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/Azure/diagnostics-eventflow</projectUrl>

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/SecureStringExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/SecureStringExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
+using Validation;
 
 namespace Microsoft.Extensions.Configuration.ServiceFabric
 {
@@ -13,10 +14,7 @@ namespace Microsoft.Extensions.Configuration.ServiceFabric
     {
         public static string ToUnsecureString(this SecureString secureString)
         {
-            if (secureString == null)
-            {
-                throw new ArgumentNullException();
-            }
+            Requires.NotNull(secureString, nameof(secureString));
 
             IntPtr unmanagedString = IntPtr.Zero;
 

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/SecureStringExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ConfigurationProvider/SecureStringExtensions.cs
@@ -1,0 +1,34 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.Extensions.Configuration.ServiceFabric
+{
+    public static class SecureStringExtensions
+    {
+        public static string ToUnsecureString(this SecureString secureString)
+        {
+            if (secureString == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            IntPtr unmanagedString = IntPtr.Zero;
+
+            try
+            {
+                unmanagedString = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+                return Marshal.PtrToStringUni(unmanagedString);
+            }
+            finally
+            {
+                Marshal.ZeroFreeGlobalAllocUnicode(unmanagedString);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides types that simplify the use of EventFlow library by Microsoft Service Fabric services.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.2</VersionPrefix>
+    <VersionPrefix>1.1.3</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFramework>net451</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
@@ -20,10 +20,11 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
     {
         public static readonly string FabricConfigurationValueReference = @"servicefabric:/(?<section>\w+)/(?<name>\w+)";
         public static readonly string FabricConfigurationFileReference = @"servicefabricfile:/(?<filename>.+)";
+        public const string DefaultConfigurationFileName = "eventFlowConfig.json";
 
         public static DiagnosticPipeline CreatePipeline(
             string healthEntityName, 
-            string configurationFileName = "eventFlowConfig.json",
+            string configurationFileName = DefaultConfigurationFileName,
             string configurationPackageName = ServiceFabricConfigurationProvider.DefaultConfigurationPackageName)
         {
             // TODO: dynamically re-configure the pipeline when configuration changes, without stopping the service


### PR DESCRIPTION
Adds support for Service Fabric encrypted settings
EventFlow configuration can be placed in arbitrary configuration package

Resolves issue https://github.com/Azure/diagnostics-eventflow/issues/77