### PR TITLE
Add a new operator '&==' to address issue #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,8 @@ Here are the supported operators:
 
 Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`
 
+Bitwise Equality: `&==` (true if bit mask is set, i.e., (lhsValue & rhsValue) == rhsValue, this is useful when filter on properties like Keywords)
+
 Regular Expression: `~=` (provide a regular expression pattern on the right)
 
 Logical: `&&`, `||`, `!` (the precedence is `!` > `&&` > `||`)

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/AlternativeEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/AlternativeEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 using System.Globalization;

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/BitwiseEqualityEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/BitwiseEqualityEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 using System.Collections.Generic;
@@ -32,7 +33,7 @@ namespace Microsoft.Diagnostics.EventFlow.FilterEvaluators
 
             if (!isValidRhsValue)
             {
-                throw new ArgumentException($"The rhs value '{value}' of &= operator is not integral type");
+                throw new ArgumentException($"The right-hand side value '{value}' of &== operator is not integral type");
             }
         }
 
@@ -43,28 +44,48 @@ namespace Microsoft.Diagnostics.EventFlow.FilterEvaluators
 
         public override bool Evaluate(EventData e)
         {
-            object propertyValue;
-            if (!e.TryGetPropertyValue(this.propertyName, out propertyValue))
+            if (e == null)
+            {
+                throw new ArgumentNullException(nameof(e));
+            }
+
+            object eventPropertyValue;
+            if (!e.TryGetPropertyValue(this.propertyName, out eventPropertyValue))
             {
                 return false;
             }
 
-            var valueAsString = propertyValue.ToString();
-            if (valueAsString.StartsWith("-"))
+            if (eventPropertyValue is long)
             {
-                long lhsValue;
-                if (long.TryParse(valueAsString, out lhsValue))
-                {
-                    return (lhsValue & this.signedRhsValue) == this.signedRhsValue;
-                }
+                return ((long)eventPropertyValue & this.signedRhsValue) == this.signedRhsValue;
             }
-            else
+            else if (eventPropertyValue is ulong)
             {
-                ulong lhsValue;
-                if(ulong.TryParse(valueAsString, out lhsValue))
-                {
-                    return (lhsValue & this.unsignedRhsValue) == this.unsignedRhsValue;
-                }
+                return ((ulong)eventPropertyValue & this.unsignedRhsValue) == this.unsignedRhsValue;
+            }
+            else if (eventPropertyValue is int)
+            {
+                return ((int)eventPropertyValue & this.signedRhsValue) == this.signedRhsValue;
+            }
+            else if (eventPropertyValue is uint)
+            {
+                return ((uint)eventPropertyValue & this.unsignedRhsValue) == this.unsignedRhsValue;
+            }
+            if (eventPropertyValue is short)
+            {
+                return ((short)eventPropertyValue & this.signedRhsValue) == this.signedRhsValue;
+            }
+            else if (eventPropertyValue is ushort)
+            {
+                return ((ushort)eventPropertyValue & this.unsignedRhsValue) == this.unsignedRhsValue;
+            }
+            else if (eventPropertyValue is sbyte)
+            {
+                return ((sbyte)eventPropertyValue & this.signedRhsValue) == this.signedRhsValue;
+            }
+            else if (eventPropertyValue is byte)
+            {
+                return ((byte)eventPropertyValue & this.unsignedRhsValue) == this.unsignedRhsValue;
             }
 
             return false;

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/BitwiseEqualityEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/BitwiseEqualityEvaluator.cs
@@ -1,0 +1,73 @@
+﻿//-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Microsoft.Diagnostics.EventFlow.FilterEvaluators
+{
+    internal class BitwiseEqualityEvaluator : EventPropertyExpressionEvaluator
+    {
+        // Convert the rhs value to both unsigned and signed format.
+        // The reason is complier will complain that operator '&' can't be applied with operands of type 'ulong' and signed value.
+        // While we do want to handle the case when the lhs value is a negative number, in this case, the signed rhs value will be used.
+        private ulong unsignedRhsValue;
+        private long signedRhsValue;
+
+        public BitwiseEqualityEvaluator(string propertyName, string value) : base(propertyName, value)
+        {
+            bool isValidRhsValue = false;
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                isValidRhsValue = ulong.TryParse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out this.unsignedRhsValue)
+                    && long.TryParse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out this.signedRhsValue);
+            }
+            else
+            {
+                isValidRhsValue = ulong.TryParse(value, out this.unsignedRhsValue)
+                    && long.TryParse(value, out this.signedRhsValue);
+            }
+
+            if (!isValidRhsValue)
+            {
+                throw new ArgumentException($"The rhs value '{value}' of &= operator is not integral type");
+            }
+        }
+
+        public override string SemanticsString
+        {
+            get { return string.Format(CultureInfo.InvariantCulture, "(__BitwiseEqualityEvaluator:{0}&=={1})", this.propertyName, this.value); }
+        }
+
+        public override bool Evaluate(EventData e)
+        {
+            object propertyValue;
+            if (!e.TryGetPropertyValue(this.propertyName, out propertyValue))
+            {
+                return false;
+            }
+
+            var valueAsString = propertyValue.ToString();
+            if (valueAsString.StartsWith("-"))
+            {
+                long lhsValue;
+                if (long.TryParse(valueAsString, out lhsValue))
+                {
+                    return (lhsValue & this.signedRhsValue) == this.signedRhsValue;
+                }
+            }
+            else
+            {
+                ulong lhsValue;
+                if(ulong.TryParse(valueAsString, out lhsValue))
+                {
+                    return (lhsValue & this.unsignedRhsValue) == this.unsignedRhsValue;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/CachingPropertyExpressionEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/CachingPropertyExpressionEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 using System.Collections.Immutable;

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/ConjunctionEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/ConjunctionEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 using System.Globalization;

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/EqualityEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/EqualityEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 using System.Globalization;

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/EventPropertyExpressionEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/EventPropertyExpressionEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/EventPropertyExpressionEvaluatorFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/EventPropertyExpressionEvaluatorFactory.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/EventPropertyExpressionEvaluatorFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/EventPropertyExpressionEvaluatorFactory.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Diagnostics.EventFlow.FilterEvaluators
                 case "~=":
                     return new RegexEvaluator(propertyName, value);
 
+                case "&==":
+                    return new BitwiseEqualityEvaluator(propertyName, value);
+
                 default:
                     throw new ArgumentException("Unknown operator", nameof(op));
             }

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/FilterEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/FilterEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 namespace Microsoft.Diagnostics.EventFlow.FilterEvaluators
 {

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/GreaterOrEqualsEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/GreaterOrEqualsEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System.Globalization;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/GreaterThanEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/GreaterThanEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System.Globalization;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/InequalityEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/InequalityEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System.Globalization;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/LessOrEqualsEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/LessOrEqualsEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System.Globalization;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/LessThanEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/LessThanEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System.Globalization;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/NegationEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/NegationEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 using System.Globalization;

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/OrderingEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/OrderingEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/PositiveEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/PositiveEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/RegexEvaluator.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/FilterEvaluators/RegexEvaluator.cs
@@ -1,6 +1,7 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
 
 using System;
 using System.Globalization;

--- a/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/FilterParser.peg
+++ b/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/FilterParser.peg
@@ -35,6 +35,7 @@ operator
   / "=="
   / "!="
   / "~="
+  / "&=="
 
 value
   = (letterDigit / "-") (letterDigit / "-" / ":" / ".")*

--- a/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/Microsoft.Diagnostics.EventFlow.FilterParserGenerator.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/Microsoft.Diagnostics.EventFlow.FilterParserGenerator.csproj
@@ -17,6 +17,9 @@
     <Compile Include="..\Microsoft.Diagnostics.EventFlow.Core\Implementations\FilterEvaluators\AlternativeEvaluator.cs">
       <Link>AlternativeEvaluator.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.Diagnostics.EventFlow.Core\Implementations\FilterEvaluators\BitwiseEqualityEvaluator.cs">
+      <Link>BitwiseEqualityEvaluator.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.Diagnostics.EventFlow.Core\Implementations\FilterEvaluators\CachingPropertyExpressionEvaluator.cs">
       <Link>CachingPropertyExpressionEvaluator.cs</Link>
     </Compile>
@@ -61,6 +64,9 @@
     </Compile>
     <Compile Include="..\Microsoft.Diagnostics.EventFlow.Core\Implementations\LogLevel.cs">
       <Link>LogLevel.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.Diagnostics.EventFlow.Core\Implementations\Metadata\DataRetrievalResult.cs">
+      <Link>DataRetrievalResult.cs</Link>
     </Compile>
     <Compile Include="..\Microsoft.Diagnostics.EventFlow.Core\Implementations\Metadata\EventMetadata.cs">
       <Link>EventMetadata.cs</Link>

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/BitwiseEqualityEvaluatorTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/BitwiseEqualityEvaluatorTests.cs
@@ -1,0 +1,206 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Microsoft.Diagnostics.EventFlow;
+using Microsoft.Diagnostics.EventFlow.FilterEvaluators;
+using Xunit;
+
+namespace Microsoft.Diagnostics.EventFlow.Core.Tests.FilterParsing
+{
+    public class BitwiseEqualityEvaluatorTests
+    {
+        private readonly FilterParser parser = new FilterParser();
+
+        [Fact]
+        public void MissingPropertyEquality()
+        {
+            var evaluator = new EqualityEvaluator("InvalidPropertyName", "0xFF");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+        }
+
+        [Fact]
+        public void BitwiseEqualityNonHexFormat()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, 0xF3);
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "3");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "4");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void BitwiseEqualityHexFormat()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, 0xF3);
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0x03");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xA4");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        public void BitwiseInequalityByNegation()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, 0xF3);
+            
+            var evaluator = new NegationEvaluator(new BitwiseEqualityEvaluator(tempPropertyName, "0x03"));
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new NegationEvaluator(new BitwiseEqualityEvaluator(tempPropertyName, "0xA4"));
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void IntPropertyEquality()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, int.Parse("FFFFABCD", System.Globalization.NumberStyles.HexNumber));
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFABC0");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFABCE");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void LongPropertyEquality()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, long.Parse("FFFFABCDFFFFABCD", System.Globalization.NumberStyles.HexNumber));
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFABC0FFFFABC0");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFABCEFFFFABCE");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload[tempPropertyName] = long.MaxValue;
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0x0FFFFFFFFFFFFFFF");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFFFFFFFFFFFFF");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload[tempPropertyName] = long.MinValue;
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0x8000000000000000");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0x8000000000000001");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void ShortPropertyEquality()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, short.Parse("FFBF", System.Globalization.NumberStyles.HexNumber));
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFBF");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFF");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void SbytePropertyEquality()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, sbyte.Parse("F3", System.Globalization.NumberStyles.HexNumber));
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xF3");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xF5");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void UintPropertyEquality()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, uint.Parse("FFFFABCD", System.Globalization.NumberStyles.HexNumber));
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFABC0");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFABCE");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void UlongPropertyEquality()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, ulong.Parse("FFFFABCDFFFFABCD", System.Globalization.NumberStyles.HexNumber));
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFABC0FFFFABC0");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFABCEFFFFABCE");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload[tempPropertyName] = ulong.MaxValue;
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFFFFFFFFFFFFFF");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void UshortPropertyEquality()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, ushort.Parse("FFBF", System.Globalization.NumberStyles.HexNumber));
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFBF");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xFFFF");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+
+        [Fact]
+        public void BytePropertyEquality()
+        {
+            var tempPropertyName = Guid.NewGuid().ToString();
+            FilteringTestData.ManyPropertiesEvent.Payload.Add(tempPropertyName, byte.Parse("F3", System.Globalization.NumberStyles.HexNumber));
+
+            var evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xF3");
+            Assert.True(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            evaluator = new BitwiseEqualityEvaluator(tempPropertyName, "0xF5");
+            Assert.False(evaluator.Evaluate(FilteringTestData.ManyPropertiesEvent));
+
+            FilteringTestData.ManyPropertiesEvent.Payload.Remove(tempPropertyName);
+        }
+    }
+}

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/EventPropertyExpressionTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/FilterParsing/EventPropertyExpressionTests.cs
@@ -132,6 +132,24 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests.FilterParsing
         }
 
         [Fact]
+        public void BinaryAndOperator()
+        {
+            var result = parser.Parse(" Keywords&==321 ");
+            Assert.Equal("(__BitwiseEqualityEvaluator:Keywords&==321)", result.SemanticsString);
+
+            result = parser.Parse("Keywords &== 321");
+            Assert.Equal("(__BitwiseEqualityEvaluator:Keywords&==321)", result.SemanticsString);
+
+            result = parser.Parse("Keywords &== 0xFF");
+            Assert.Equal("(__BitwiseEqualityEvaluator:Keywords&==0xFF)", result.SemanticsString);
+
+            result = parser.Parse("!(Keywords &== 0xFF)");
+            Assert.Equal("(NOT(__BitwiseEqualityEvaluator:Keywords&==0xFF))", result.SemanticsString);
+
+            Assert.Throws(typeof(ArgumentException), () => parser.Parse("Keywords &== abc"));
+        }
+
+        [Fact]
         public void InvalidOperatorSpacing()
         {
             Assert.ThrowsAny<Exception>(() => parser.Parse(" delta> =17 "));


### PR DESCRIPTION
Add a new operator '&=='. This is used to test the bit mask of the property value, which can be used to filter on properties like Keywords.