### PR TITLE
EventFlow pipeline simplification and hardening

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporterExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporterExtensions.cs
@@ -1,0 +1,18 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Diagnostics.EventFlow
+{
+    internal static class HealthReporterExtensions
+    {
+        public static void ReportThrottling(this IHealthReporter healthReporter)
+        {
+            healthReporter.ReportWarning("An event was dropped from the diagnostic pipeline because there was not enough capacity",
+                    EventFlowContextIdentifiers.Throttling);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/LossReportingPropagatorBlock.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/LossReportingPropagatorBlock.cs
@@ -1,0 +1,215 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow
+{
+    /// <summary>
+    /// The purpose of this class is to ensure that EventFlow pipeline does not drop events without warning through the health reporter.
+    /// This is a possiblity with BroadcastBlock, which, by design, will discard the current message once a new message arrives and the 
+    /// current message has been offered to all downstream blocks. This happens regardless whether the message was accepted, postponed
+    /// or discarded by the downstream block. 
+    /// The LossReportingPropagatorBlock works around this issue by reporting a message loss when a passing message is discarded by the downstream block,
+    /// or when a message is postponed and then not available for consumption later on.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class LossReportingPropagatorBlock<T> : IPropagatorBlock<T, T>
+    {
+        private IHealthReporter healthReporter;
+        private ITargetBlock<T> target;
+        private ISourceBlock<T> source;
+        private bool propagateCompletion;
+        private bool completed;
+        private Lazy<TaskCompletionSource<bool>> completionSource;
+        private long postponements;
+        private long consumptionAttempts;
+
+        public LossReportingPropagatorBlock(IHealthReporter healthReporter)
+        {
+            Requires.NotNull(healthReporter, nameof(healthReporter));
+            this.healthReporter = healthReporter;
+            this.target = null;
+            this.propagateCompletion = false;
+            this.completed = false;
+            this.completionSource = new Lazy<TaskCompletionSource<bool>>(LazyThreadSafetyMode.PublicationOnly);
+            this.postponements = this.consumptionAttempts = 0;
+        }
+
+        public Task Completion { get { return this.completionSource.Value.Task; } }
+
+        public void Complete()
+        {
+            this.completed = true;
+            this.completionSource.Value.TrySetResult(true);
+
+            if (this.propagateCompletion)
+            {
+                Debug.Assert(this.target != null);
+                this.target.Complete();                
+            }
+
+            if (this.postponements > this.consumptionAttempts)
+            {
+                // Once we are completed, it won't be possible to consume any postponed messages and any postponed messages will effectively be lost.
+                this.healthReporter.ReportThrottling();
+            }
+        }
+
+        public void Fault(Exception exception)
+        {
+            this.completed = true;
+
+            if (this.propagateCompletion)
+            {
+                Debug.Assert(this.target != null);
+                this.target.Fault(exception);
+
+                // If the pipeline is faulted, the data loss is pretty much inevitable, so it does not make that much sense to report data loss here.
+                // (we theoretically could check for this.postponements > this.consumptionAttempts).
+            }
+            else
+            {
+                this.completionSource.Value.TrySetException(exception);
+            }
+        }
+
+        public IDisposable LinkTo(ITargetBlock<T> target, DataflowLinkOptions linkOptions)
+        {
+            Requires.NotNull(target, nameof(target));
+            if (this.target != null)
+            {
+                throw new InvalidOperationException($"{nameof(LossReportingPropagatorBlock<T>)} only supports a single target");
+            }
+
+            this.target = target;
+            if (linkOptions != null)
+            {
+                // Note DataflowLinkOptions.Append does not matter given that we are working with a single target only 
+                // and we will not enforce DataflowLinkOptions.MaxMessages
+                this.propagateCompletion = linkOptions.PropagateCompletion;
+            }
+
+            // We do not support re-linking
+            return new EmptyDisposable();
+        }
+
+        public DataflowMessageStatus OfferMessage(DataflowMessageHeader messageHeader, T messageValue, ISourceBlock<T> source, bool consumeToAccept)
+        {
+            VerifySourceInitiatedOperation(source);
+
+            if (this.completed)
+            {
+                return DataflowMessageStatus.DecliningPermanently;
+            }
+
+            if (consumeToAccept)
+            {
+                // The target is asked to synchronously call back via ConsumeMessage(). Since we are counting consumption attempts
+                // and verify that postponements == consumption attempts (that happens upon completion), 
+                // we have to increment the postponements count here.
+                Interlocked.Increment(ref this.postponements);
+            }
+
+            var targetResponse = this.target.OfferMessage(messageHeader, messageValue, this, consumeToAccept);
+            switch (targetResponse)
+            {
+                case DataflowMessageStatus.Accepted:
+                    // Great, nothing to do
+                    break;
+
+                case DataflowMessageStatus.Declined:
+                case DataflowMessageStatus.DecliningPermanently:
+                case DataflowMessageStatus.NotAvailable:
+                    this.healthReporter.ReportThrottling();
+                    break;
+
+                case DataflowMessageStatus.Postponed:
+                    // This is a bit of a tricky situation in the sense that we cannot determine at the moment whether the loss occurred or not.
+                    // The message might be successfully consumed later, or it might no longer be available.
+                    // We'll know for sure based on the success/failure of ConsumeMessage().
+                    Interlocked.Increment(ref this.postponements);
+                    break;
+            }
+
+            return targetResponse;
+        }
+
+        public T ConsumeMessage(DataflowMessageHeader messageHeader, ITargetBlock<T> target, out bool messageConsumed)
+        {
+            VerifyTargetInitiatedOperation(target);
+
+            messageConsumed = false;
+
+            if (this.completed)
+            {
+                return default(T);
+            }
+
+            Interlocked.Increment(ref this.consumptionAttempts);
+
+            T message = this.source.ConsumeMessage(messageHeader, this, out bool consumedByMe);
+            if (consumedByMe)
+            {
+                messageConsumed = true;
+                return message;
+            }
+            else
+            {
+                // Message is no longer available
+                this.healthReporter.ReportThrottling();
+                return default(T);
+            }
+        }
+
+        public void ReleaseReservation(DataflowMessageHeader messageHeader, ITargetBlock<T> target)
+        {
+            VerifyTargetInitiatedOperation(target);
+
+            if (!this.completed)
+            {
+                this.source.ReleaseReservation(messageHeader, this);
+            }
+        }
+
+        public bool ReserveMessage(DataflowMessageHeader messageHeader, ITargetBlock<T> target)
+        {
+            VerifyTargetInitiatedOperation(target);
+
+            if (this.completed)
+            {
+                return false;
+            }
+
+            bool reserved = this.source.ReserveMessage(messageHeader, this);
+            if (!reserved)
+            {
+                // If we cannot reserve the message, it means it is gone before our target had a chance to consume it
+                // (either overwritten, or reserved by some other target). Either way we need to warn about the loss.
+                this.healthReporter.ReportThrottling();
+            }
+            return reserved;
+        }
+
+        private void VerifyTargetInitiatedOperation(ITargetBlock<T> target)
+        {
+            Verify.Operation(this.source != null, "The block must have a source");
+            Verify.Operation(object.ReferenceEquals(this.target, target), "Only single target is supported");
+        }
+
+        private void VerifySourceInitiatedOperation(ISourceBlock<T> source)
+        {
+            Verify.Operation(this.target != null, "The block must have a target");
+            // Make sure we set the source reference only once
+            Interlocked.CompareExchange(ref this.source, source, null);
+            Verify.Operation(object.ReferenceEquals(this.source, source), "Only single source block is supported");
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/TargetBlockObserver.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/TargetBlockObserver.cs
@@ -16,17 +16,14 @@ namespace Microsoft.Diagnostics.EventFlow
     {
         private readonly ITargetBlock<TInput> target;
         private readonly IHealthReporter healthReporter;
-        private readonly Action newValueAction;
 
-        public TargetBlockObserver(ITargetBlock<TInput> target, IHealthReporter healthReporter, Action newValueAction)
+        public TargetBlockObserver(ITargetBlock<TInput> target, IHealthReporter healthReporter)
         {
             Requires.NotNull(target, nameof(target));
             Requires.NotNull(healthReporter, nameof(healthReporter));
-            Requires.NotNull(newValueAction, nameof(newValueAction));
 
             this.target = target;
             this.healthReporter = healthReporter;
-            this.newValueAction = newValueAction;
         }
 
         internal Task<bool> SendAsyncToTarget(TInput value)
@@ -48,11 +45,7 @@ namespace Microsoft.Diagnostics.EventFlow
         {
             if (!target.Post(value))
             {
-                healthReporter.ReportWarning("An event was dropped from the diagnostic pipeline because there was not enough capacity", EventFlowContextIdentifiers.Throttling);
-            }
-            else
-            {
-                newValueAction();
+                healthReporter.ReportThrottling();
             }
         }
     }

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DataflowTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DataflowTests.cs
@@ -1,0 +1,540 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Xunit;
+
+using Microsoft.Diagnostics.EventFlow.TestHelpers;
+
+namespace Microsoft.Diagnostics.EventFlow.Core.Tests
+{
+    // These test do not verify EventFlow functionality, but rather they confirm assumptions about TPL Dataflow library,
+    // upon which the EventFlow pipeline is built.
+    public class DataflowTests
+    {
+        private static readonly DataflowLinkOptions PropagateCompletion = new DataflowLinkOptions() { PropagateCompletion = true };
+        private static readonly TimeSpan MessageArrivalTimeout = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan CompletionTimeout = TimeSpan.FromMilliseconds(1000);
+
+        [Fact]
+        public Task BufferBlockKeepsPostponedMessages()
+        {
+            return BlockKeepsPostponedMessages(() => new BufferBlock<int>(new DataflowBlockOptions()
+                { BoundedCapacity = 3 }));
+        }
+
+        [Fact]
+        public Task BufferBlockKeepsDeclinedMessages()
+        {
+            return BlockKeepsDeclinedMessages(
+                () => new BufferBlock<int>(new DataflowBlockOptions() { BoundedCapacity = 3 }),
+                (block) => ((BufferBlock<int>)block).Count);
+        }
+
+        [Fact]
+        public Task BufferBlockWillCompleteTarget()
+        {
+            return BlockWillCompleteTarget(() => new BufferBlock<int>(new DataflowBlockOptions()
+                { BoundedCapacity = 3 }));
+        }
+
+        [Fact]
+        public Task BufferBlockStuckCompletionCannotBeCancelled()
+        {
+            return StuckCompletionCannotBeCancelled(
+                (cancellationToken) => new BufferBlock<int>(new DataflowBlockOptions()
+                    { BoundedCapacity = 3, CancellationToken = cancellationToken }),
+                (block) => ((BufferBlock<int>) block).Count);
+        }
+
+        [Fact]
+        public async Task BatchBlockKeepsPostponedMessages()
+        {
+            BatchBlock<int> bb = new BatchBlock<int>( batchSize: 2,
+                dataflowBlockOptions: new GroupingDataflowBlockOptions() { BoundedCapacity = 3 });
+
+            TestTargetBlock<int[]> testTarget = new TestTargetBlock<int[]>();
+            testTarget.ConsumptionMode = DataflowMessageStatus.Postponed;
+            bb.LinkTo(testTarget, PropagateCompletion);
+
+            // Assumption: if the target of the BatchBlock is postponing messages, 
+            // BatchBlock will accept incoming messages until it runs out of capacity.
+            Assert.True(bb.Post(1));
+            Assert.True(bb.Post(2));
+
+            // Still able to accept one more message
+            Assert.True(bb.Post(3));
+
+            // Out of capacity. 
+            Assert.False(bb.Post(4));
+
+            // Send() a message to give the block a chance to postpone it
+            bb.SendAsync(5).Forget();
+
+            // First batch offered, but postponed
+            bool gotFirstBatch = await TaskUtils.PollWaitAsync(() => testTarget.MessagesPostponed.Count == 1, MessageArrivalTimeout);
+            Assert.True(gotFirstBatch);
+
+            // Assumption: once the BatchBlock target stops postponing, BatchBlock will keep pushing data to target 
+            // until it runs out of buffered messages.
+            testTarget.ConsumptionMode = DataflowMessageStatus.Accepted;
+            testTarget.ConsumePostponedMessages();
+
+            // The second, postponed message should allow the block to complete two batches
+            bool gotTwoBatches = await TaskUtils.PollWaitAsync(() => testTarget.MessagesConsumed.Count == 2, MessageArrivalTimeout);
+            Assert.True(gotTwoBatches);
+            Assert.True(testTarget.MessagesConsumed.All((m) => m.Length == 2));
+        }        
+
+        [Fact]
+        public async Task BatchBlockKeepsDeclinedMessages()
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+            BatchBlock<int> bb = new BatchBlock<int>(batchSize: 2,
+                dataflowBlockOptions: new GroupingDataflowBlockOptions() { BoundedCapacity = 3, CancellationToken = cts.Token });
+
+            TestTargetBlock<int[]> testTarget = new TestTargetBlock<int[]>();
+            testTarget.ConsumptionMode = DataflowMessageStatus.Declined;
+            bb.LinkTo(testTarget, PropagateCompletion);
+
+            // Assumption: BatchBlock will keep incoming messages even when its target is declining them
+            Assert.True(bb.Post(1));
+            Assert.True(bb.Post(2));
+            Assert.True(bb.Post(3));
+
+            // The block has run out of capacity
+            Assert.False(bb.Post(4));
+            Assert.False(bb.Post(5));
+
+            // This message will be postponed (and, in fact, released when we ask the block to complete)
+            bb.SendAsync(6).Forget();
+
+            // The messages are buffered and there is one batch ready to be consumed (the second one is not full)
+            Assert.Equal(1, bb.OutputCount);
+
+            // Wait till the block offers a message
+            // Assumption: only one message will be offered, the block will not offer more messages if the target declines
+            bool oneMessageOffered = await TaskUtils.PollWaitAsync(() => testTarget.MessagesDeclined.Count == 1, MessageArrivalTimeout);
+            Assert.True(oneMessageOffered);
+            Assert.True(testTarget.MessagesConsumed.Count == 0);
+            Assert.True(testTarget.MessagesPostponed.Count == 0);
+
+            // Assumption: the block will NOT try to deliver declined messages again when asked to complete.
+            // The fact that the buffer is not empty will prevent it from completing
+            testTarget.ConsumptionMode = DataflowMessageStatus.Accepted;
+            bb.Complete();
+            bool someMessagesDelivered = await TaskUtils.PollWaitAsync(() => testTarget.MessagesConsumed.Count > 0, MessageArrivalTimeout);
+            Assert.False(someMessagesDelivered);
+
+            // Because we asked the BatchBlock for completion, it now formed a second, undersize batch
+            Assert.Equal(2, bb.OutputCount);
+
+            // Completion task should still be running
+            await Task.WhenAny(bb.Completion, Task.Delay(CompletionTimeout));
+            Assert.False(bb.Completion.IsCompleted);
+
+            // Assumption: BatchBlock will not start target's completion until it itself completes
+            await Task.WhenAny(testTarget.Completion, Task.Delay(CompletionTimeout));
+            Assert.True(testTarget.Completion.IsNotStarted());
+        }
+
+        [Fact]
+        public async Task BatchBlockWillCompleteTarget()
+        {
+            BatchBlock<int> bb = new BatchBlock<int>(batchSize: 2,
+                dataflowBlockOptions: new GroupingDataflowBlockOptions() { BoundedCapacity = 3 });
+
+            TestTargetBlock<int[]> testTarget = new TestTargetBlock<int[]>();
+            testTarget.ConsumptionMode = DataflowMessageStatus.Accepted;
+            bb.LinkTo(testTarget, PropagateCompletion);
+
+            // Rapidly send 50 messages
+            TimeSpan sendTimeout = TimeSpan.FromSeconds(10);
+            Task.WaitAll(Enumerable.Range(0, 50).Select((i) => bb.SendAsync(i)).ToArray(), sendTimeout);
+
+            bb.Complete();
+
+            // Completion should run to successful conclusion
+            await Task.WhenAny(bb.Completion, Task.Delay(CompletionTimeout));
+            Assert.Equal(TaskStatus.RanToCompletion, bb.Completion.Status);
+
+            // Assumption: BufferBlock should also have completed its target
+            await Task.WhenAny(testTarget.Completion, Task.Delay(CompletionTimeout));
+            Assert.Equal(TaskStatus.RanToCompletion, testTarget.Completion.Status);
+
+            // Assumption: we should have gotten 25 batches
+            bool allMessagesReceived = await TaskUtils.PollWaitAsync(() => testTarget.MessagesConsumed.Count == 25, MessageArrivalTimeout);
+            Assert.True(allMessagesReceived);
+        }
+
+        [Fact]
+        public async Task BatchBlockStuckCompletionCannotBeCancelled()
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+            BatchBlock<int> bb = new BatchBlock<int>(batchSize: 2,
+                dataflowBlockOptions: new GroupingDataflowBlockOptions() {
+                    BoundedCapacity = 3, CancellationToken = cts.Token });
+
+            TestTargetBlock<int[]> testTarget = new TestTargetBlock<int[]>();
+            testTarget.ConsumptionMode = DataflowMessageStatus.Declined;
+            bb.LinkTo(testTarget, PropagateCompletion);
+
+            Assert.True(bb.Post(1));
+            Assert.True(bb.Post(2));
+            Assert.True(bb.Post(3));
+
+            bb.Complete();
+
+            // Completion task should still be running
+            await Task.WhenAny(bb.Completion, Task.Delay(CompletionTimeout));
+            Assert.False(bb.Completion.IsCompleted);
+
+            // Assumption: BatchBlock will not start target's completion until it itself completes
+            await Task.WhenAny(testTarget.Completion, Task.Delay(CompletionTimeout));
+            Assert.True(testTarget.Completion.IsNotStarted());
+
+            // Assumption: cancellation does not affect the completion of the block (unfortunately!)
+            cts.Cancel();
+            await Task.WhenAny(bb.Completion, Task.Delay(CompletionTimeout));
+            Assert.False(bb.Completion.IsCompleted);
+            await Task.WhenAny(testTarget.Completion, Task.Delay(CompletionTimeout));
+            Assert.True(testTarget.Completion.IsNotStarted());
+            
+            // The block still has 2 batches: one full, one undersize
+            Assert.Equal(2, bb.OutputCount);
+        }
+
+        [Fact]
+        public Task TransformBlockKeepsPostponedMessages()
+        {
+            return BlockKeepsPostponedMessages(() => new TransformBlock<int, int>(
+                transform: (int a) => a,
+                dataflowBlockOptions: new ExecutionDataflowBlockOptions
+                {
+                    BoundedCapacity = 3,
+                    MaxDegreeOfParallelism = 2,
+                    SingleProducerConstrained = false
+                }));
+        }
+
+        [Fact]
+        public Task TransformBlockKeepsDeclinedMessages()
+        {
+            return BlockKeepsDeclinedMessages(
+                () => new TransformBlock<int, int>(
+                transform: (int a) => a,
+                dataflowBlockOptions: new ExecutionDataflowBlockOptions
+                {
+                    BoundedCapacity = 3,
+                    MaxDegreeOfParallelism = 2,
+                    SingleProducerConstrained = false
+                }),
+                (block) => ((TransformBlock<int, int>) block).OutputCount);
+        }
+
+        [Fact]
+        public Task TransformBlockWillCompleteTarget()
+        {
+            return BlockWillCompleteTarget(() => new TransformBlock<int, int>(
+                transform: (int a) => a,
+                dataflowBlockOptions: new ExecutionDataflowBlockOptions
+                {
+                    BoundedCapacity = 3,
+                    MaxDegreeOfParallelism = 2,
+                    SingleProducerConstrained = false
+                }));
+        }
+
+        [Fact]
+        public Task TransformBlockStuckCompletionCannotBeCancelled()
+        {
+            return StuckCompletionCannotBeCancelled(
+                (cancellationToken) => new TransformBlock<int, int>(
+                    transform: (int a) => a,
+                    dataflowBlockOptions: new ExecutionDataflowBlockOptions
+                    {
+                        BoundedCapacity = 3,
+                        MaxDegreeOfParallelism = 2,
+                        SingleProducerConstrained = false,
+                        CancellationToken = cancellationToken
+                    }),
+                (block) => ((TransformBlock<int, int>)block).OutputCount);
+        }
+
+        [Fact]
+        public async Task BroadcastBlockOverwritesElementsAfterAllTargetsHaveBeenOffered()
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+            BroadcastBlock<int> bb = new BroadcastBlock<int>((i) => i,
+                new DataflowBlockOptions
+                {
+                    BoundedCapacity = 3,
+                    CancellationToken = cts.Token
+                });
+
+            TestTargetBlock<int> t1 = new TestTargetBlock<int>();
+            t1.ConsumptionMode = DataflowMessageStatus.Accepted;
+            TestTargetBlock<int> t2 = new TestTargetBlock<int>();
+            t2.ConsumptionMode = DataflowMessageStatus.Declined;
+            TestTargetBlock<int> t3 = new TestTargetBlock<int>();
+            t3.ConsumptionMode = DataflowMessageStatus.Postponed;
+
+            bb.LinkTo(t1, PropagateCompletion);
+            bb.LinkTo(t2, PropagateCompletion);
+            bb.LinkTo(t3, PropagateCompletion);
+
+            // Rapidly send 50 messages
+            TimeSpan sendTimeout = TimeSpan.FromSeconds(1);
+            Task.WaitAll(Enumerable.Range(0, 50).Select((i) => bb.SendAsync(i)).ToArray(), sendTimeout);
+
+            // Assumption: all 50 messages will go through, even though t2 is declining them and t3 is postponing.
+            bool target1ConsumedAllMessages = await TaskUtils.PollWaitAsync(() => t1.MessagesConsumed.Count == 50, MessageArrivalTimeout);
+            Assert.True(target1ConsumedAllMessages);
+            bool target2RejectedAllMessages = await TaskUtils.PollWaitAsync(() => t2.MessagesDeclined.Count == 50, MessageArrivalTimeout);
+            Assert.True(target2RejectedAllMessages);
+            bool target3PostponedAllMessages = await TaskUtils.PollWaitAsync(() => t3.MessagesPostponed.Count == 50, MessageArrivalTimeout);
+            Assert.True(target3PostponedAllMessages);
+        }
+
+        [Fact]
+        public Task BroadcastBlockWillCompleteTarget()
+        {
+            return BlockWillCompleteTarget(() => new BroadcastBlock<int>((i) => i,
+                new DataflowBlockOptions
+                {
+                    BoundedCapacity = 3
+                }));
+        }
+
+        [Fact]
+        public async Task BroadcastBlockDoesNotRememberMoreThanOnePostponedMessage()
+        {
+            BroadcastBlock<int> bb = new BroadcastBlock<int>((i) => i,
+                new DataflowBlockOptions
+                {
+                    BoundedCapacity = 3
+                });
+
+            TestTargetBlock<int> target = new TestTargetBlock<int>();
+            target.ConsumptionMode = DataflowMessageStatus.Postponed;
+            bb.LinkTo(target, PropagateCompletion);
+
+            bb.Post(1);
+            bb.Post(2);
+            await TaskUtils.PollWaitAsync(() => target.MessagesPostponed.Count == 2, MessageArrivalTimeout);
+
+            target.ConsumePostponedMessages();
+            // Assumption: only one message (the last one) will be successfully consumed. The previous message was overwritten, 
+            // so when the target inquires about it, it is gone.
+            Assert.Equal(1, target.MessagesConsumed.Count);
+        }
+
+        [Fact]
+        public async Task ActionBlockBuffersAndPostponesMessagesWhenActionSlow()
+        {
+            int processedMessageCount = 0;
+            TimeSpan ProcessingTime = TimeSpan.FromMilliseconds(50);
+            TimeSpan ProcessingTimeTimesTen = TimeSpan.FromMilliseconds(500);
+
+            ActionBlock<int> ab = new ActionBlock<int>(
+                (msgId) => 
+                {
+                    Task.Delay(ProcessingTime);
+                    Interlocked.Increment(ref processedMessageCount);
+                },
+                new ExecutionDataflowBlockOptions
+                {
+                    BoundedCapacity = 3,
+                    MaxDegreeOfParallelism = 2,
+                    SingleProducerConstrained = false
+                });
+
+            // Send 10 messages as fast as possible
+            TimeSpan sendTimeout = TimeSpan.FromSeconds(1);
+            Task.WaitAll(Enumerable.Range(0, 10).Select((i) => ab.SendAsync(i)).ToArray(), sendTimeout);
+
+            // Assumption: all will be eventually processed. 
+            bool allProcessed = await TaskUtils.PollWaitAsync(() => processedMessageCount == 10, ProcessingTimeTimesTen + MessageArrivalTimeout);
+            Assert.True(allProcessed);
+        }
+
+        [Fact]
+        public async Task ActionBlockWillProcessAllAcceptedMessagesBeforeCompletion()
+        {
+            int processedMessageCount = 0;
+            TimeSpan ProcessingTime = TimeSpan.FromMilliseconds(50);
+            TimeSpan ProcessingTimeTimesTen = TimeSpan.FromMilliseconds(500);
+
+            ActionBlock<int> ab = new ActionBlock<int>(
+                (msgId) =>
+                {
+                    Task.Delay(ProcessingTime);
+                    Interlocked.Increment(ref processedMessageCount);
+                },
+                new ExecutionDataflowBlockOptions
+                {
+                    BoundedCapacity = 3,
+                    MaxDegreeOfParallelism = 2,
+                    SingleProducerConstrained = false
+                });
+
+            // Send 10 messages as fast as possible
+            TimeSpan sendTimeout = TimeSpan.FromSeconds(1);
+            Task.WaitAll(Enumerable.Range(0, 10).Select((i) => ab.SendAsync(i)).ToArray(), sendTimeout);
+
+            // Wait for completion and ensure that it does not time out and that all messages were processed before completion.
+            ab.Complete();
+            await Task.WhenAny(ab.Completion, Task.Delay(ProcessingTimeTimesTen + MessageArrivalTimeout));
+            Assert.True(ab.Completion.IsCompleted);
+            Assert.Equal(10, processedMessageCount);
+        }
+
+        private async Task BlockKeepsDeclinedMessages(Func<ISourceBlock<int>> BlockFactory, Func<ISourceBlock<int>, int> OutputCount)
+        {
+            ISourceBlock<int> block = BlockFactory();
+            ITargetBlock<int> blockT = (ITargetBlock<int>)block;
+
+            TestTargetBlock<int> testTarget = new TestTargetBlock<int>();
+            testTarget.ConsumptionMode = DataflowMessageStatus.Declined;
+            block.LinkTo(testTarget, PropagateCompletion);
+
+            // Assumption: block will keep incoming messages even when its target is declining them
+            Assert.True(blockT.Post(1));
+            Assert.True(blockT.Post(2));
+            Assert.True(blockT.Post(3));
+
+            // The block has run out of capacity
+            Assert.False(blockT.Post(4));
+
+            // This message will be postponed (and, in fact, released when we ask the block to complete)
+            blockT.SendAsync(5).Forget();            
+
+            // Wait till the block offers a message
+            // Assumption: only one message will be offered, the block will not offer more messages if the target declines
+            bool oneMessageOffered = await TaskUtils.PollWaitAsync(() => testTarget.MessagesDeclined.Count == 1, MessageArrivalTimeout);
+            Assert.True(oneMessageOffered);
+            Assert.True(testTarget.MessagesConsumed.Count == 0);
+            Assert.True(testTarget.MessagesPostponed.Count == 0);
+
+            // The messages are buffered
+            Assert.Equal(3, OutputCount(block));
+
+            // Assumption: the block will try NOT to deliver declined messages again when asked to complete.
+            testTarget.ConsumptionMode = DataflowMessageStatus.Accepted;
+            block.Complete();
+            bool someMessagesDelivered = await TaskUtils.PollWaitAsync(() => testTarget.MessagesConsumed.Count > 0, MessageArrivalTimeout);
+            Assert.False(someMessagesDelivered);
+
+            // Completion task should still be running
+            await Task.WhenAny(block.Completion, Task.Delay(CompletionTimeout));
+            Assert.False(block.Completion.IsCompleted);
+
+            // Assumption: block will not start target's completion until it itself completes
+            await Task.WhenAny(testTarget.Completion, Task.Delay(CompletionTimeout));
+            Assert.True(testTarget.Completion.IsNotStarted());
+        }
+
+        private async Task BlockKeepsPostponedMessages(Func<ISourceBlock<int>> BlockFactory)
+        {
+            ISourceBlock<int> block = BlockFactory();
+            ITargetBlock<int> blockT = (ITargetBlock<int>)block;
+
+            TestTargetBlock<int> testTarget = new TestTargetBlock<int>();
+            testTarget.ConsumptionMode = DataflowMessageStatus.Postponed;
+            block.LinkTo(testTarget, PropagateCompletion);
+
+            // Assumption: if the target of the block is postponing messages, 
+            // The block will accept incoming messages until it runs out of capacity.
+            Assert.True(blockT.Post(1));
+            Assert.True(blockT.Post(2));
+            Assert.True(blockT.Post(3));
+
+            // Out of capacity
+            Assert.False(blockT.Post(4));
+
+            // However SendAsync() will allow postponing the message, sot the message will be eventually delivered
+            blockT.SendAsync(5).Forget();
+
+            // Wait till the block offers a message
+            // Assumption: only one message will be offered, the block will not offer more messages if the target postpones
+            bool messageOffered = await TaskUtils.PollWaitAsync(() => testTarget.MessagesPostponed.Count == 1, MessageArrivalTimeout);
+            Assert.True(messageOffered);
+
+            // Assumption: once the block target stops postponing, the block will keep pushing data to target 
+            // until it runs out of buffered messages.
+            testTarget.ConsumptionMode = DataflowMessageStatus.Accepted;
+            testTarget.ConsumePostponedMessages();
+            // Use 10 times the normal message arrival timeout for extra padding--the test tended to be a bit flakey at this point.
+            // If this happens again, switch to custom TaskScheduler.
+            bool gotAllMessages = await TaskUtils.PollWaitAsync(() => testTarget.MessagesConsumed.Count == 4, TimeSpan.FromMilliseconds(MessageArrivalTimeout.TotalMilliseconds * 10));
+            Assert.True(gotAllMessages, "We should have gotten 4 messages");
+            Assert.Equal(testTarget.MessagesConsumed.OrderBy((i) => i), new int[] { 1, 2, 3, 5 });
+        }
+
+        private async Task BlockWillCompleteTarget(Func<ISourceBlock<int>> BlockFactory)
+        {
+            ISourceBlock<int> block = BlockFactory();
+
+            TestTargetBlock<int> testTarget = new TestTargetBlock<int>();
+            testTarget.ConsumptionMode = DataflowMessageStatus.Accepted;
+            block.LinkTo(testTarget, PropagateCompletion);
+
+            // Rapidly send 50 messages
+            TimeSpan sendTimeout = TimeSpan.FromSeconds(1);
+            Task.WaitAll(Enumerable.Range(0, 50).Select((i) => ((ITargetBlock<int>)block).SendAsync(i)).ToArray(), sendTimeout);
+
+            block.Complete();
+
+            // Completion should run to successful conclusion
+            await Task.WhenAny(block.Completion, Task.Delay(CompletionTimeout));
+            Assert.Equal(TaskStatus.RanToCompletion, block.Completion.Status);
+
+            // Assumption: the block should also have completed its target
+            await Task.WhenAny(testTarget.Completion, Task.Delay(CompletionTimeout));
+            Assert.Equal(TaskStatus.RanToCompletion, testTarget.Completion.Status);
+
+            // Assumption: we should have gotten 50 messages
+            bool allMessagesReceived = await TaskUtils.PollWaitAsync(() => testTarget.MessagesConsumed.Count == 50, MessageArrivalTimeout);
+            Assert.True(allMessagesReceived);
+        }
+
+        private async Task StuckCompletionCannotBeCancelled(Func<CancellationToken, ISourceBlock<int>> BlockFactory, Func<ISourceBlock<int>, int> OutputCount)
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            ISourceBlock<int> block = BlockFactory(cts.Token);
+            ITargetBlock<int> blockT = (ITargetBlock<int>)block;
+
+            TestTargetBlock<int> testTarget = new TestTargetBlock<int>();
+            testTarget.ConsumptionMode = DataflowMessageStatus.Declined;
+            block.LinkTo(testTarget, PropagateCompletion);
+
+            Assert.True(blockT.Post(1));
+            Assert.True(blockT.Post(2));
+
+            block.Complete();
+
+            // Completion task should still be running
+            await Task.WhenAny(block.Completion, Task.Delay(CompletionTimeout));
+            Assert.False(block.Completion.IsCompleted);
+
+            // Assumption: BufferBlock will not start target's completion until it itself completes
+            await Task.WhenAny(testTarget.Completion, Task.Delay(CompletionTimeout));
+            Assert.True(testTarget.Completion.IsNotStarted());
+
+            // Assumption: cancellation does not affect the completion of the block (unfortunately!)
+            cts.Cancel();
+            await Task.WhenAny(block.Completion, Task.Delay(CompletionTimeout));
+            Assert.False(block.Completion.IsCompleted);
+            await Task.WhenAny(testTarget.Completion, Task.Delay(CompletionTimeout));
+            Assert.True(testTarget.Completion.IsNotStarted());
+            Assert.Equal(2, OutputCount(block));
+        }
+    }
+}

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/TestTargetBlock.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/TestTargetBlock.cs
@@ -1,0 +1,122 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Validation;
+using Xunit;
+
+namespace Microsoft.Diagnostics.EventFlow.Core.Tests
+{
+    internal class TestTargetBlock<T> : ITargetBlock<T>
+    {
+        private TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
+        private DataflowMessageStatus consumptionMode = DataflowMessageStatus.Accepted;
+
+        public Task Completion => this.tcs.Task;
+        public readonly ConcurrentQueue<PostponedMessageRecord<T>> MessagesPostponed = new ConcurrentQueue<PostponedMessageRecord<T>>();
+        public readonly ConcurrentQueue<T> MessagesConsumed = new ConcurrentQueue<T>();
+        public readonly ConcurrentQueue<T> MessagesDeclined = new ConcurrentQueue<T>();
+
+        public DataflowMessageStatus ConsumptionMode
+        {
+            get => this.consumptionMode;
+            set
+            {
+                Requires.Range(value != DataflowMessageStatus.NotAvailable, nameof(ConsumptionMode));
+                this.consumptionMode = value;
+            }
+        }
+
+        public void Complete()
+        {
+            lock (this.tcs)
+            {
+                if (Completion.Status == TaskStatus.RanToCompletion)
+                {
+                    return;
+                }
+
+                this.tcs.SetResult(true);
+                this.consumptionMode = DataflowMessageStatus.DecliningPermanently;
+            }
+        }
+
+        public void Fault(Exception exception)
+        {
+            lock (this.tcs)
+            {
+                this.tcs.SetException(exception);
+                this.consumptionMode = DataflowMessageStatus.DecliningPermanently;
+            }
+        }
+
+        public DataflowMessageStatus OfferMessage(DataflowMessageHeader messageHeader, T messageValue, ISourceBlock<T> source, bool consumeToAccept)
+        {
+            switch(this.consumptionMode)
+            {
+                case DataflowMessageStatus.Accepted:
+                    T message;
+                    bool messageConsumed = true;
+
+                    if (consumeToAccept)
+                    {
+                        message = source.ConsumeMessage(messageHeader, this, out messageConsumed);
+                        Assert.True(messageConsumed, "If consumeToAccept flag is set, ConsumeMessage() should have succeeded");
+                    }
+                    else
+                    {
+                        message = messageValue;
+                    }
+                    if (messageConsumed)
+                    {
+                        this.MessagesConsumed.Enqueue(messageValue);
+                    }
+                    break;
+
+                case DataflowMessageStatus.Postponed:
+                    this.MessagesPostponed.Enqueue(new PostponedMessageRecord<T>()
+                    {
+                        MessageHeader = messageHeader,
+                        MessageValue = messageValue,
+                        Source = source
+                    });
+                    break;
+
+                case DataflowMessageStatus.Declined:
+                case DataflowMessageStatus.DecliningPermanently:
+                    this.MessagesDeclined.Enqueue(messageValue);
+                    break;
+            }
+
+            return this.consumptionMode;
+        }
+
+        public void ConsumePostponedMessages()
+        {
+            while(this.MessagesPostponed.TryDequeue(out PostponedMessageRecord<T> postponedMessageRecord))
+            {
+                T message = postponedMessageRecord.Source.ConsumeMessage(postponedMessageRecord.MessageHeader, this, out bool messageConsumed);
+                if (messageConsumed)
+                {
+                    this.MessagesConsumed.Enqueue(message);
+                }
+            }
+        }
+    }
+
+    internal class PostponedMessageRecord<T>
+    {
+        public DataflowMessageHeader MessageHeader;
+        public T MessageValue;
+        public ISourceBlock<T> Source;
+    }
+}

--- a/test/TestHelpers/DeterministicTaskScheduler.cs
+++ b/test/TestHelpers/DeterministicTaskScheduler.cs
@@ -1,0 +1,66 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+
+namespace Microsoft.Diagnostics.EventFlow.TestHelpers
+{
+    /// <summary>
+    /// TaskScheduker for executing tasks on the same thread that calls RunTasksUntilIdle() or RunPendingTasks().
+    /// </summary>
+    public class DeterministicTaskScheduler : TaskScheduler
+    {
+        private List<Task> scheduledTasks;
+
+        public DeterministicTaskScheduler() : base()
+        {
+            scheduledTasks = new List<Task>();
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            this.scheduledTasks.Add(task);
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            return base.TryExecuteTask(task);
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks() => this.scheduledTasks;
+
+        public override int MaximumConcurrencyLevel => 1;
+
+        public IEnumerable<Task> ScheduledTasks => this.scheduledTasks;
+
+        /// <summary>
+        /// Executes the scheduled Tasks synchronously on the current thread. If those tasks schedule new tasks
+        /// they will also be executed until no pending tasks are left.
+        /// </summary>
+        public void RunTasksUntilIdle()
+        {
+            while (this.scheduledTasks.Any())
+            {
+                this.RunPendingTasks();
+            }
+        }
+
+        /// <summary>
+        /// Executes the scheduled Tasks synchronously on the current thread. If those tasks schedule new tasks
+        /// they will only be executed with the next call to RunTasksUntilIdle() or RunPendingTasks(). 
+        /// </summary>
+        public void RunPendingTasks()
+        {
+            foreach (var task in this.scheduledTasks.ToArray())
+            {
+                base.TryExecuteTask(task);
+                this.scheduledTasks.Remove(task);
+            }
+        }
+    }
+}

--- a/test/TestHelpers/TaskExtensions.cs
+++ b/test/TestHelpers/TaskExtensions.cs
@@ -1,0 +1,17 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.EventFlow.TestHelpers
+{
+    public static class TaskExtensions
+    {
+        public static void Forget(this Task task) { }
+
+        // TaskStatus.WaitingForActiviation is used for tasks that depend on other tasks, such as ones created with .ContinueWith()
+        public static bool IsNotStarted(this Task task) => task.Status == TaskStatus.Created || task.Status == TaskStatus.WaitingForActivation;
+    }
+}

--- a/test/TestHelpers/TaskUtils.cs
+++ b/test/TestHelpers/TaskUtils.cs
@@ -1,0 +1,29 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.EventFlow.TestHelpers
+{
+    public static class TaskUtils
+    {
+        private static readonly TimeSpan JustABit = TimeSpan.FromMilliseconds(20);
+
+        public static async Task<bool> PollWaitAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            DateTime doNotExceedTime = DateTime.Now + timeout;
+            while (!condition())
+            {
+                await Task.Delay(JustABit);
+                if (DateTime.Now > doNotExceedTime)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This change addressed some outstanding issues with EventFlow pipeline

1. Pipeline disposal is too complex and at the same time will take longer than necessary if throttling occurred during operation. This is because we employ event counting scheme to determine when the pipeline is drained, but if events are throttled, the count will be off and we will wait till completion timeout for events that were throttled long ago.

2. Because of how BroadcastBlock works we might not warn the consumer of the pipeline if throttling occurs. 