### PR TITLE
Address several issues related to Application Insights integration

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
@@ -4,7 +4,7 @@
     <Description>Provides an implementation of Application Insights telemetry processor that feeds Application Insights telemetry into EventFlow pipeline. 
     This allows sending diagnostics data from applications instrumented with Application Insights to destinations other than Application Insights service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451</TargetFrameworks>
     <DelaySign>true</DelaySign>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/ApplicationInsightsOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/ApplicationInsightsOutput.cs
@@ -139,25 +139,18 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
 
             if (string.IsNullOrWhiteSpace(aiOutputConfiguration.ConfigurationFilePath))
             {
-                if (string.IsNullOrWhiteSpace(aiOutputConfiguration.InstrumentationKey))
-                {
-                    string errorMessage = $"{nameof(ApplicationInsightsOutput)}: Application Insights instrumentation key is not set)";
-                    this.healthReporter.ReportProblem(errorMessage, EventFlowContextIdentifiers.Configuration);
-                    throw new Exception(errorMessage);
-                }
-
-                this.telemetryClient = new TelemetryClient();
-                this.telemetryClient.InstrumentationKey = aiOutputConfiguration.InstrumentationKey;
+                this.telemetryClient = new TelemetryClient();                
             }
             else
             {
                 string configurationFileContent = File.ReadAllText(aiOutputConfiguration.ConfigurationFilePath);
                 TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.CreateFromConfiguration(configurationFileContent);
-                if (!string.IsNullOrWhiteSpace(aiOutputConfiguration.InstrumentationKey))
-                {
-                    telemetryConfiguration.InstrumentationKey = aiOutputConfiguration.InstrumentationKey;
-                }
                 this.telemetryClient = new TelemetryClient(telemetryConfiguration);
+            }
+
+            if (!string.IsNullOrWhiteSpace(aiOutputConfiguration.InstrumentationKey))
+            {
+                this.telemetryClient.InstrumentationKey = aiOutputConfiguration.InstrumentationKey;
             }
         }
 

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an output implementation that sends diagnostics data to Microsoft Application Insights service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFramework>net451</TargetFramework>
     <DelaySign>true</DelaySign>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -28,7 +28,7 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
This pull request addresses the following issues

[Update ApplicationInsights SDK ref to 2.3](https://github.com/Azure/diagnostics-eventflow/issues/71)
[ApplicationInsights output should not require instrumentation key or configuration](https://github.com/Azure/diagnostics-eventflow/issues/91)
[Application Insights output: failure to decorate event with metadata should not result in data loss](https://github.com/Azure/diagnostics-eventflow/issues/95)


