### PR TITLE
Allow empty configuration values in Service Fabric overrides

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides types that simplify the use of EventFlow library by Microsoft Service Fabric services.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.1.4</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFramework>net451</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
                     {
                         string valueReferencePath = ConfigurationPath.Combine(valueReferenceMatch.Groups["section"].Value, valueReferenceMatch.Groups["name"].Value);
                         string newValue = configurationRoot[valueReferencePath];
-                        if (string.IsNullOrEmpty(newValue))
+                        if (newValue == null)
                         {
                             healthReporter.ReportWarning(
                                 $"Configuration value reference '{kvp.Value}' was encountered but no corresponding configuration value was found using path '{valueReferencePath}'", 


### PR DESCRIPTION
Fixes https://github.com/Azure/diagnostics-eventflow/issues/97