### PR TITLE
Include content of the error response from OMS ingestion endpoint

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Oms</AssemblyName>
     <AssemblyOriginatorKeyFile>../../PublicKey.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.Oms</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Microsoft Operations Management</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
@@ -124,7 +124,14 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                 }
                 else
                 {
-                    string errorMessage = nameof(OmsOutput) + "OMS REST API returned an error. Code: " + response.StatusCode + " Description: " + response.ReasonPhrase;
+                    string responseContent = string.Empty;
+                    try
+                    {
+                        responseContent = await response.Content.ReadAsStringAsync();
+                    }
+                    catch { }
+
+                    string errorMessage = $"{nameof(OmsOutput)}: OMS REST API returned an error. Code: {response.StatusCode} Description: {response.ReasonPhrase} {responseContent}";
                     this.healthReporter.ReportProblem(errorMessage);
                 }
             }


### PR DESCRIPTION
This addresses issue https://github.com/Azure/diagnostics-eventflow/issues/104 