### PR TITLE
Nested scopes in MicrosoftLogging input logged as single Scope property

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLogger.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLogger.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Internal;
 

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLogger.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLogger.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Internal;
 
@@ -47,6 +49,8 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             }
 
             var scope = EventFlowLoggerScope.Current;
+            List<string> scopePropertyValues = new List<string>(5);
+
             while (scope != null)
             {
                 if (scope?.State != null)
@@ -61,15 +65,20 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
                         }
 
                         //last KV is the whole 'scope' message, we will add it formatted
-                        AddPayloadProperty(properties, "Scope", formattedState.ToString());
+                        scopePropertyValues.Add(formattedState.ToString());
                     }
                     else
                     {
-                        AddPayloadProperty(properties, "Scope", scope.State);
+                        scopePropertyValues.Add(scope.State.ToString());
                     }
                 }
 
                 scope = scope.Parent;
+            }
+
+            if (scopePropertyValues.Count > 0)
+            {
+                AddPayloadProperty(properties, "Scope", string.Join(" > ", scopePropertyValues.AsEnumerable().Reverse()));
             }
 
             loggerInput.SubmitEventData(message, ToLogLevel(logLevel), eventId, exception, categoryName, properties);

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/LoggerInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/LoggerInputTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
                             LogLevel.Informational,
                             0,
                             null,
-                            new Dictionary<string, object> { { "Scope", state }, { "number", 1 } }))), Times.Exactly(1));
+                            new Dictionary<string, object> { { "Scope", state.ToString() }, { "number", 1 } }))), Times.Exactly(1));
                     }
                 }
             }
@@ -306,9 +306,8 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
 
                                 subject.Verify(s => s.OnNext(It.IsAny<EventData>()), Times.Exactly(1));
                                 var scopeProperties = savedData.Payload.Where(kvp => kvp.Key.StartsWith("Scope")).ToArray();
-                                Assert.True(scopeProperties.Length == 2);
-                                Assert.True((string)scopeProperties[0].Value == "scope1 inner");
-                                Assert.True((string)scopeProperties[1].Value == "scope1 outer");
+                                Assert.True(scopeProperties.Length == 1);
+                                Assert.True((string)scopeProperties[0].Value == "scope1 outer > scope1 inner");
 
                                 waitOnTask1.Set();
                             }
@@ -329,9 +328,8 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
 
                                 subject.Verify(s => s.OnNext(It.IsAny<EventData>()), Times.Exactly(2));
                                 var scopeProperties = savedData.Payload.Where(kvp => kvp.Key.StartsWith("Scope")).ToArray();
-                                Assert.True(scopeProperties.Length == 2);
-                                Assert.True((string)scopeProperties[0].Value == "scope2 inner");
-                                Assert.True((string)scopeProperties[1].Value == "scope2 outer");
+                                Assert.True(scopeProperties.Length == 1);
+                                Assert.True((string)scopeProperties[0].Value == "scope2 outer > scope2 inner");
                             }
                         }
                     });

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/LoggerInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/LoggerInputTests.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
                                 subject.Verify(s => s.OnNext(It.IsAny<EventData>()), Times.Exactly(1));
                                 var scopeProperties = savedData.Payload.Where(kvp => kvp.Key.StartsWith("Scope")).ToArray();
                                 Assert.True(scopeProperties.Length == 1);
-                                Assert.True((string)scopeProperties[0].Value == "scope1 outer > scope1 inner");
+                                Assert.True((string)scopeProperties[0].Value == "scope1 outer\r\nscope1 inner");
 
                                 waitOnTask1.Set();
                             }
@@ -329,7 +329,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
                                 subject.Verify(s => s.OnNext(It.IsAny<EventData>()), Times.Exactly(2));
                                 var scopeProperties = savedData.Payload.Where(kvp => kvp.Key.StartsWith("Scope")).ToArray();
                                 Assert.True(scopeProperties.Length == 1);
-                                Assert.True((string)scopeProperties[0].Value == "scope2 outer > scope2 inner");
+                                Assert.True((string)scopeProperties[0].Value == "scope2 outer\r\nscope2 inner");
                             }
                         }
                     });


### PR DESCRIPTION
Current version of MicrosoftLogging input logs nested scopes to multiple Scope properties resulting in health check warnings as multiple property keys are not allowed. Also Scope values are assigned to different random keys (Scope, Scope_<x>).
This PR changes the behavior to log all nested scopes to a single Scope property with a value syntax:
OuterScope > InnerScope > InnerMostScope
The change causes the Scope property value to be stringified.
Tests have been modified to reflect the changes.