### PR TITLE
Logging Errors and Exceptions for Application Insights

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInput.cs
@@ -3,10 +3,10 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-using Microsoft.Diagnostics.EventFlow.Metadata;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Diagnostics.EventFlow.Metadata;
 using Serilog.Events;
 using Validation;
 using Serilog.Core;

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInput.cs
@@ -79,17 +79,19 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
 
             var payload = eventData.Payload;
 
-            if (logEvent.Level >= LogEventLevel.Error) {
-                EventMetadata eventMetadata = new EventMetadata(ExceptionData.ExceptionMetadataKind);
-                eventMetadata.Properties.Add(ExceptionData.ExceptionPropertyMoniker, "Exception");
-                eventData.SetMetadata(eventMetadata);
-            }
-
             // Prefer the built-in `Message` and `Exception` properties by adding them to the payload
             // first. If other attached data items have conflicting names, they will be added as
             // `Message_1` and so-on.
             if (logEvent.Exception != null)
             {
+
+                if (logEvent.Level >= LogEventLevel.Error) 
+                {
+                    EventMetadata eventMetadata = new EventMetadata(ExceptionData.ExceptionMetadataKind);
+                    eventMetadata.Properties.Add(ExceptionData.ExceptionPropertyMoniker, "Exception");
+                    eventData.SetMetadata(eventMetadata);
+                }
+                
                 eventData.AddPayloadProperty("Exception", logEvent.Exception, healthReporter, nameof(SerilogInput));
             }
 

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/SerilogInput.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using Microsoft.Diagnostics.EventFlow.Metadata;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -77,6 +78,12 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             };
 
             var payload = eventData.Payload;
+
+            if (logEvent.Level >= LogEventLevel.Error) {
+                EventMetadata eventMetadata = new EventMetadata(ExceptionData.ExceptionMetadataKind);
+                eventMetadata.Properties.Add(ExceptionData.ExceptionPropertyMoniker, "Exception");
+                eventData.SetMetadata(eventMetadata);
+            }
 
             // Prefer the built-in `Message` and `Exception` properties by adding them to the payload
             // first. If other attached data items have conflicting names, they will be added as

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/SerilogInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/SerilogInputTests.cs
@@ -106,12 +106,12 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
             }
         }
 
-        private bool ContainsException(EventData data, Exception exception1) {
+        private bool ContainsException(EventData data, Exception expectedException) {
             IReadOnlyCollection<EventMetadata> metaData;
             data.TryGetMetadata(ExceptionData.ExceptionMetadataKind, out metaData);
             foreach (EventMetadata eventMetadata in metaData) {
                 Exception exception = (Exception)data.Payload[eventMetadata.Properties[ExceptionData.ExceptionPropertyMoniker]];
-                return exception == exception1;
+                return exception == expectedException;
             }
             return false;
         }


### PR DESCRIPTION
With this change I would like to enable the Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsightsOutput to Track Exceptions instead of Trace in order to find Errors and Criticals in the WebUI of Application Insights and create Alarms for those kind of events.