### PR TITLE
Fix deadlock in EventSourceInput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ project.lock.json
 /nugets/
 
 .vscode
+/.vs/Warsaw/v15/sqlite3/*.ide

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventDataExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventDataExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             }
             if (eventSourceEvent.RelatedActivityId != default(Guid))
             {
-                payloadData.Add(nameof(EventWrittenEventArgs.RelatedActivityId), eventSourceEvent.RelatedActivityId.ToString());
+                payloadData.Add(nameof(EventWrittenEventArgs.RelatedActivityId), ActivityPathDecoder.GetActivityPathString(eventSourceEvent.RelatedActivityId));
             }
 
             try

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Tracing.EventSource infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <DelaySign>true</DelaySign>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EventSourceInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EventSourceInputTests.cs
@@ -7,11 +7,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Threading.Tasks;
 using Moq;
 using Xunit;
 
 using Microsoft.Diagnostics.EventFlow.Inputs;
 using Microsoft.Diagnostics.EventFlow.Configuration;
+
 
 namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
 {
@@ -30,6 +32,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
                 ProviderName = "EventSourceInput-TestEventSource"
             });
             var eventSourceInput = new EventSourceInput(inputConfiguration, healthReporterMock.Object);
+            eventSourceInput.Activate();
 
             var observer = new Mock<IObserver<EventData>>();
             using (eventSourceInput.Subscribe(observer.Object))
@@ -52,6 +55,72 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
             }
         }
 
+        [Fact]
+        public void CapturesEventsFromEventSourceExistingBeforeInputCreated()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+
+            var inputConfiguration = new List<EventSourceConfiguration>();
+            inputConfiguration.Add(new EventSourceConfiguration()
+            {
+                ProviderName = "EventSourceInput-TestEventSource"
+            });
+
+            // EventSourceInputTestSource has a static instance that exists before the input is created.
+            // But it won't be actually hooked up to EventSource/EventListener infrastructure until an event is raised.
+            EventSourceInputTestSource.Log.Message("ignored");
+
+            var eventSourceInput = new EventSourceInput(inputConfiguration, healthReporterMock.Object);
+            eventSourceInput.Activate();
+
+            var observer = new Mock<IObserver<EventData>>();
+            using (eventSourceInput.Subscribe(observer.Object))
+            {
+                
+                EventSourceInputTestSource.Log.Message("Hello!");
+
+                observer.Verify(s => s.OnNext(It.Is<EventData>(data =>
+                       data.Payload["Message"].Equals("Hello!")
+                    && data.Payload["EventId"].Equals(2)
+                    && data.Payload["EventName"].Equals("Message")                    
+                )), Times.Exactly(1));
+
+                healthReporterMock.Verify(o => o.ReportWarning(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                healthReporterMock.Verify(o => o.ReportProblem(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            }
+        }
+
+        [Fact]
+        public void CapturesEventsFromEventSourceCreatedAfterInputCreated()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+
+            var inputConfiguration = new List<EventSourceConfiguration>();
+            inputConfiguration.Add(new EventSourceConfiguration()
+            {
+                ProviderName = "EventSourceInput-OtherTestEventSource"
+            });
+
+            var eventSourceInput = new EventSourceInput(inputConfiguration, healthReporterMock.Object);
+            eventSourceInput.Activate();
+
+            var observer = new Mock<IObserver<EventData>>();
+            using (eventSourceInput.Subscribe(observer.Object))
+            using (var eventSource = new EventSourceInputTestOtherSource())
+            {
+                eventSource.Message("Wow!");
+
+                observer.Verify(s => s.OnNext(It.Is<EventData>(data =>
+                       data.Payload["Message"].Equals("Wow!")
+                    && data.Payload["EventId"].Equals(3)
+                    && data.Payload["EventName"].Equals("Message")
+                )), Times.Exactly(1));
+
+                healthReporterMock.Verify(o => o.ReportWarning(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+                healthReporterMock.Verify(o => o.ReportProblem(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            }
+        }
+
         [EventSource(Name = "EventSourceInput-TestEventSource")]
         private class EventSourceInputTestSource : EventSource
         {
@@ -61,6 +130,22 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
             public void Tricky(int EventId, string EventName, string Message)
             {
                 WriteEvent(1, EventId, EventName, Message);
+            }
+
+            [Event(2, Level = EventLevel.Informational, Message ="{0}")]
+            public void Message(string message)
+            {
+                WriteEvent(2, message);
+            }
+        }
+
+        [EventSource(Name = "EventSourceInput-OtherTestEventSource")]
+        private class EventSourceInputTestOtherSource: EventSource
+        {
+            [Event(3, Level = EventLevel.Informational, Message = "{0}")]
+            public void Message(string message)
+            {
+                WriteEvent(3, message);
             }
         }
     }


### PR DESCRIPTION
The problem was originally reported by users of ApplicationInsights EventSourceTelemetryModule, but I believe EventSourceInput suffers from the same problem.

Also fixed a small issue related to issue https://github.com/Azure/diagnostics-eventflow/issues/124 (RelatedActivityId should be path-decoded, just like ActivityID).