### PR TITLE
Fix https://github.com/Azure/diagnostics-eventflow/issues/142

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Tracing.EventSource infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.1.4</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <DelaySign>true</DelaySign>


### PR DESCRIPTION
GetSystemTimePreciseAsFileTime function in EventDataExtensions not supported on operating systems before Windows 8