### PR TITLE
Add capability to disable EventSources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,8 @@ project.lock.json
 /nugets/
 
 .vscode
+.vs
 
 *.ide
 *.ide-journal
+

--- a/README.md
+++ b/README.md
@@ -143,20 +143,31 @@ This input listens to EventSource traces. EventSource classes can be created in 
 }
 ```
 
-*Top Object*
+*Top object*
 
 | Field | Values/Types | Required | Description |
 | :---- | :-------------- | :------: | :---------- |
 | `type` | "EventSource" | Yes | Specifies the input type. For this input, it must be "EventSource". |
 | `sources` | JSON array | Yes | Specifies the EventSource objects to collect. |
 
-*Sources Object*
+*Source object (element of the sources array)*
 
 | Field | Values/Types | Required | Description |
 | :---- | :-------------- | :------: | :---------- |
-| `providerName` | provider name | Yes | Specifies the name of the EventSource to track. |
-| `level` | Critial, Error, Warning, Informational, Verbose, LogAlways | No | Specifies the collection trace level. Traces with equal or higher severity than specified are collected. For example, if Warning is specified, then Critial, Error, and Warning traces are collected. Default is LogAlways, which means "provider decides what events are raised", which usually results in all events being raised. |
-|`keywords` | An integer | No | A bitmask that specifies what events to collect. Only events with keyword matching the bitmask are collected, except if it's 0, which means everything is collected. Default is 0. |
+| `providerName` | EventSource name | Yes(*) | Specifies the name of the EventSource to track. |
+| `providerNamePrefix` | EventSource name prefix | Yes(*) | Specifies the name prefix of EventSource(s) to track. For example, if the value is "Microsoft-ServiceFabric", all EventSources that have names starting with Microsoft-ServiceFabric (Microsoft-ServiceFabric-Services, Microsoft-ServiceFabric-Actors and so on) will be tracked. |
+| `disabledProviderNamePrefix` | provider name | Yes(*) | Specifies the name prefix of the EventSource(s) that must be ignored. No events from these sources will be captured(***). |
+| `level` | Critial, Error, Warning, Informational, Verbose, LogAlways | No(**) | Specifies the collection trace level. Traces with equal or higher severity than specified are collected. For example, if Warning is specified, then Critial, Error, and Warning traces are collected. Default is LogAlways, which means "provider decides what events are raised", which usually results in all events being raised. |
+|`keywords` | An integer | No(**) | A bitmask that specifies what events to collect. Only events with keyword matching the bitmask are collected, except if it's 0, which means everything is collected. Default is 0. |
+
+*Remarks*
+
+(*) Out of `providerName`, `providerNamePrefix` and `disabledProviderNamePrefix`, only one can be used for a single source. In other words, with a single source one can enable an EventSource by name, or enable a set of EventSources by prefix, or disable a set of EventSources by prefix.
+
+(**) `level` and `keywords` can be used for enabling EventSources, but not for disabling them. Disabling events using level and keywords is not supported (but one can use level and/or keywords to *selectively enable* a subset of events from a given EventSource).
+
+(***) There is an issue with .NET frameworks 4.6 and 4.7, and .NET Core framework 1.1 and 2.0 where dynamically created EventSource events are dispatched to all listeners, regardless whether listeners subscribe to events from these EventSources; for more information see https://github.com/dotnet/coreclr/issues/14434  `disabledProviderNamePrefix` property can be usesd to suppress these events.<br/>
+Disabling EventSources is not recommended under normal circumstances, as it introduces a slight performance penalty. Instead, selectively enable necessary events through combination of EventSource names, event levels, and keywords.
 
 #### PerformanceCounter
 *Nuget Package*: [**Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter**](https://www.nuget.org/packages/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/)

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Configuration/EventSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Configuration/EventSourceConfiguration.cs
@@ -3,7 +3,10 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+using System.Linq;
 using System.Diagnostics.Tracing;
+using Validation;
 
 namespace Microsoft.Diagnostics.EventFlow.Configuration
 {
@@ -12,13 +15,62 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
     public class EventSourceConfiguration
     {
         public string ProviderName { get; set; }
-        public EventLevel Level { get; set; }
-        public EventKeywords Keywords { get; set; }
+        public EventLevel Level { get; set; } = EventLevel.LogAlways;
+        public EventKeywords Keywords { get; set; } = EventKeywords.All;
+        public string DisabledProviderNamePrefix { get; set; }
+        public string ProviderNamePrefix { get; set; }
 
-        public EventSourceConfiguration()
+        public bool Validate()
         {
-            Level = EventLevel.LogAlways;
-            Keywords = (EventKeywords) ~0;
+            bool[] enabledSettings = new bool[]
+            {
+                !string.IsNullOrWhiteSpace(ProviderName),
+                !string.IsNullOrWhiteSpace(ProviderNamePrefix),
+                !string.IsNullOrWhiteSpace(DisabledProviderNamePrefix)
+            };
+
+            // One and only one setting should be present
+            if (enabledSettings.Count(setting => setting) != 1)
+            {
+                return false;
+            }
+
+            // If disabling, Keywords and Level must remain at default values (the are ineffective)
+            if (!string.IsNullOrWhiteSpace(DisabledProviderNamePrefix))
+            {
+                if (Keywords != EventKeywords.All || Level != EventLevel.LogAlways)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool Enables(EventSource eventSource)
+        {
+            Requires.NotNull(eventSource, nameof(eventSource));
+
+            if (!string.IsNullOrWhiteSpace(ProviderName))
+            {
+                return eventSource.Name == ProviderName;
+            }
+            else if (!string.IsNullOrWhiteSpace(ProviderNamePrefix))
+            {
+                return eventSource.Name?.StartsWith(ProviderNamePrefix, StringComparison.Ordinal) ?? false;
+            }
+            else return false;
+        }
+
+        public bool Disables(EventSource eventSource)
+        {
+            Requires.NotNull(eventSource, nameof(eventSource));
+
+            if (!string.IsNullOrWhiteSpace(DisabledProviderNamePrefix))
+            {
+                return eventSource.Name?.StartsWith(DisabledProviderNamePrefix, StringComparison.Ordinal) ?? false;
+            }
+            else return false;
         }
 
         public override bool Equals(object obj)
@@ -29,12 +81,33 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
                 return false;
             }
 
-            return ProviderName == other.ProviderName && Level == other.Level && Keywords == other.Keywords;
+            if (ProviderName != other.ProviderName || 
+                ProviderNamePrefix != other.ProviderNamePrefix || 
+                DisabledProviderNamePrefix != other.DisabledProviderNamePrefix || 
+                Level != other.Level || 
+                Keywords != other.Keywords)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public override int GetHashCode()
         {
-            return ProviderName?.GetHashCode() ?? 0;
+            if (ProviderName != null)
+            {
+                return ProviderName.GetHashCode();
+            }
+            else if (ProviderNamePrefix != null)
+            {
+                return ProviderNamePrefix.GetHashCode();
+            }
+            else if (DisabledProviderNamePrefix != null)
+            {
+                return DisabledProviderNamePrefix.GetHashCode();
+            }
+            else return 0;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Tracing.EventSource infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <DelaySign>true</DelaySign>


### PR DESCRIPTION
A useful feature in itself, but also constitutes a workaround for [issue 140](https://github.com/Azure/diagnostics-eventflow/issues/140)