### PR TITLE
Exposed more ElasticSearch config to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ This output writes data to the [Elasticsearch](https://www.elastic.co/products/e
 ```json
 {
     "type": "ElasticSearch",
-    "indexNamePrefix": "app1-",
+    "indexNamePrefix": "app1",
     "serviceUri": "https://myElasticSearchCluster:9200",
     "basicAuthenticationUserName": "esUser1",
     "basicAuthenticationUserPassword": "<MyPassword>",

--- a/README.md
+++ b/README.md
@@ -597,7 +597,10 @@ This output writes data to the [Elasticsearch](https://www.elastic.co/products/e
     "serviceUri": "https://myElasticSearchCluster:9200",
     "basicAuthenticationUserName": "esUser1",
     "basicAuthenticationUserPassword": "<MyPassword>",
-    "eventDocumentTypeName": "diagData"
+    "eventDocumentTypeName": "diagData",
+    "numberOfShards": 1,
+    "numberOfReplicas": 1,
+    "refreshInterval": "15s"
 }
 ```
 | Field | Values/Types | Required | Description |
@@ -608,6 +611,9 @@ This output writes data to the [Elasticsearch](https://www.elastic.co/products/e
 | `basicAuthenticationUserName` | string | No | Specifies the user name used to authenticate with Elasticsearch. To protect the cluster, authentication is often setup on the cluster. |
 | `basicAuthenticationUserPassword` | string | No | Specifies the password used to authenticate with Elasticsearch. This field should be used only if basicAuthenticationUserName is specified. |
 | `eventDocumentTypeName` | string | Yes | Specifies the document type to be applied when data is written. Elasticsearch allows documents to be typed, so they can be distinguished from other types. This type name is user-defined. |
+| `numberOfShards` | int | No | Specifies how many shards to create the index with. If not specified, it defaults to 1.|
+| `numberOfReplicas` | int | No | Specifies how many replicas the index is created with. If not specified, it defaults to 5.|
+| `refreshInterval` | string | No | Specifies what refresh interval the index is created with. If not specified, it defaults to 15s.|
 
 *Standard metadata support*
 

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchOutputConfiguration.cs
@@ -10,16 +10,25 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
     public class ElasticSearchOutputConfiguration: ItemConfiguration
     {
         public static readonly string DefaultEventDocumentTypeName = "event";
+        public static readonly int DefaultNumberOfShards = 1;
+        public static readonly int DefaultNumberOfReplicas = 5;
+        public static readonly string DefaultRefreshInterval = "15s";
 
         public string IndexNamePrefix { get; set; }
         public string ServiceUri { get; set; }
         public string BasicAuthenticationUserName { get; set; }
         public string BasicAuthenticationUserPassword { get; set; }
         public string EventDocumentTypeName { get; set; }
+        public int NumberOfShards { get; set; }
+        public int NumberOfReplicas { get; set; }
+        public string RefreshInterval { get; set; }
 
         public ElasticSearchOutputConfiguration()
         {
             EventDocumentTypeName = DefaultEventDocumentTypeName;
+            NumberOfShards = DefaultNumberOfShards;
+            NumberOfReplicas = DefaultNumberOfReplicas;
+            RefreshInterval = DefaultRefreshInterval;
         }
 
         public ElasticSearchOutputConfiguration DeepClone()
@@ -30,7 +39,10 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
                 ServiceUri = this.ServiceUri,
                 BasicAuthenticationUserName = this.BasicAuthenticationUserName,
                 BasicAuthenticationUserPassword = this.BasicAuthenticationUserPassword,
-                EventDocumentTypeName = this.EventDocumentTypeName
+                EventDocumentTypeName = this.EventDocumentTypeName,
+                NumberOfShards = this.NumberOfShards,
+                NumberOfReplicas = this.NumberOfReplicas,
+                RefreshInterval = this.RefreshInterval,
             };
 
             return other;

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
@@ -413,7 +413,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
         private string GetIndexName(ElasticSearchConnectionData connectionData)
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
-            string retval = connectionData.Configuration.IndexNamePrefix + now.Year.ToString() + Dot + now.Month.ToString() + Dot + now.Day.ToString();
+            string retval = connectionData.Configuration.IndexNamePrefix + now.ToString("yyyy" + Dot + "MM" + Dot + "dd");
             return retval;
         }
 

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
@@ -383,13 +383,13 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             {
                 return;
             }
-
+            
             // TODO: allow the consumer to fine-tune index settings
             IndexState indexSettings = new IndexState();
             indexSettings.Settings = new IndexSettings();
-            indexSettings.Settings.NumberOfReplicas = 1;
-            indexSettings.Settings.NumberOfShards = 5;
-            indexSettings.Settings.Add("refresh_interval", "15s");
+            indexSettings.Settings.NumberOfReplicas = this.connectionData.Configuration.NumberOfReplicas;
+            indexSettings.Settings.NumberOfShards = this.connectionData.Configuration.NumberOfShards;
+            indexSettings.Settings.Add("refresh_interval", this.connectionData.Configuration.RefreshInterval);
 
             ICreateIndexResponse createIndexResult = await esClient.CreateIndexAsync(indexName, c => c.InitializeUsing(indexSettings)).ConfigureAwait(false);
 

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj
@@ -21,6 +21,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <Version>2.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Core\Microsoft.Diagnostics.EventFlow.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Trace\Microsoft.Diagnostics.EventFlow.Inputs.Trace.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj" />
   </ItemGroup>
 
@@ -25,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.EventSource\Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
+    <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />    


### PR DESCRIPTION
Exposes the following settings to be user-defined:

- `NumberOfShards` (Default: 1)
- `NumberOfReplicas` (Default: 5)
- `RefreshInterval` (Default 15s)

Added a test to verify that the `ElasticSearchOutputConfiguration` is properly populated.
Updated `README.MD` to reflect those changes.

Fixed a type in `README.MD` regarding Index prefix. The example showed the Index prefix with a trailing `-`. This is not needed since it's added by code.

Updated the Date generation for Index name to use leading zeros (instead of 2017.5.22 it will be 2017.05.22). This is in-line with how all official ElasticSearch tools (Logstash, Beats) generate dates for time-based series.