### PR TITLE
Add support for complex key in sf referenced configuration

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
@@ -18,7 +18,9 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
 {
     public static class ServiceFabricDiagnosticPipelineFactory
     {
-        public static readonly string FabricConfigurationValueReference = @"servicefabric:/(?<section>\w+)/(?<name>.+)";
+        // The "name" capture group will math any combinatione of one or more "words" '\w',
+        // and separators as dot '.', underscore '_' (captured by \w). dash '-', colon ':', slash '/', and hash '#'
+        public static readonly string FabricConfigurationValueReference = @"servicefabric:/(?<section>\w+)/(?<name>[\w.\-:/#]+)";
         public static readonly string FabricConfigurationFileReference = @"servicefabricfile:/(?<filename>.+)";
         public const string DefaultConfigurationFileName = "eventFlowConfig.json";
 

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
 {
     public static class ServiceFabricDiagnosticPipelineFactory
     {
-        // The "name" capture group will math any combinatione of one or more "words" '\w',
-        // and separators as dot '.', underscore '_' (captured by \w). dash '-', colon ':', slash '/', and hash '#'
+        // The "<name>" capture group will match any combination of, one or more, words '\w'
+        // and separators as: dot '.', underscore '_' (captured by \w), dash '\-', colon ':', slash '/', and hash '#'.
         public static readonly string FabricConfigurationValueReference = @"servicefabric:/(?<section>\w+)/(?<name>[\w.\-:/#]+)";
         public static readonly string FabricConfigurationFileReference = @"servicefabricfile:/(?<filename>.+)";
         public const string DefaultConfigurationFileName = "eventFlowConfig.json";

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/ServiceFabricDiagnosticPipelineFactory.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
 {
     public static class ServiceFabricDiagnosticPipelineFactory
     {
-        public static readonly string FabricConfigurationValueReference = @"servicefabric:/(?<section>\w+)/(?<name>\w+)";
+        public static readonly string FabricConfigurationValueReference = @"servicefabric:/(?<section>\w+)/(?<name>.+)";
         public static readonly string FabricConfigurationFileReference = @"servicefabricfile:/(?<filename>.+)";
         public const string DefaultConfigurationFileName = "eventFlowConfig.json";
 
         public static DiagnosticPipeline CreatePipeline(
-            string healthEntityName, 
+            string healthEntityName,
             string configurationFileName = DefaultConfigurationFileName,
             string configurationPackageName = ServiceFabricConfigurationProvider.DefaultConfigurationPackageName)
         {
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
         }
 
         internal static IConfigurationRoot ApplyFabricConfigurationOverrides(
-            this IConfigurationRoot configurationRoot, 
+            this IConfigurationRoot configurationRoot,
             string configPackagePath,
             IHealthReporter healthReporter)
         {
@@ -94,7 +94,7 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric
                         if (newValue == null)
                         {
                             healthReporter.ReportWarning(
-                                $"Configuration value reference '{kvp.Value}' was encountered but no corresponding configuration value was found using path '{valueReferencePath}'", 
+                                $"Configuration value reference '{kvp.Value}' was encountered but no corresponding configuration value was found using path '{valueReferencePath}'",
                                 EventFlowContextIdentifiers.Configuration);
                         }
                         else

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/ServiceFabricTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/ServiceFabricTests.cs
@@ -83,13 +83,8 @@ namespace Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests
         [InlineData("charlie-delta")]
         [InlineData("charlie_delta")]
         [InlineData("charlie:delta")]
-        [InlineData("charlie\\delta")]
         [InlineData("charlie/delta")]
-        [InlineData("charlie?delta")]
-        [InlineData("charlie!delta")]
-        [InlineData("charlie$delta")]
         [InlineData("charlie#delta")]
-        [InlineData("charlie@delta")]
         public void ReferencedKeyCanContainComplexKey(string complexKey)
         {
             var healthReporterMock = new Mock<IHealthReporter>();


### PR DESCRIPTION
The reason for this PR is that I would like to be able to reference Service Fabric configuration with keys containing symbols like dots, hyphens, and other common separators.

To support such key names, I loosened up the matching regex for the key name capture, as that is the part which more commonly contains structured keys as "Elasticsearch.Url", while the section part is not as frequently structured with separators.

This assumption may not be correct as it is based on my experience with Service Fabric, which is not very extensive, I apologize if mistaken.