### PR TITLE
Adding optional configuration switch to use Azure Gov base URL for OMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Microsoft.Diagnostics.EventFlow
+﻿# Microsoft.Diagnostics.EventFlow
 
 ## Introduction
 The EventFlow library suite allows applications to define what diagnostics data to collect, and where they should be outputted to. Diagnostics data can be anything from performance counters to application traces.
@@ -668,7 +668,8 @@ The OMS output writes data to [Operations Management Suite](https://www.microsof
 {
   "type": "OmsOutput",
   "workspaceId": "<workspace-GUID>",
-  "workspaceKey": "<base-64-encoded workspace key>"
+  "workspaceKey": "<base-64-encoded workspace key>",
+  "useAzureGov" : "<optional-boolean>"
 }
 ```
 
@@ -679,7 +680,9 @@ Supported configuration settings are:
 | `type` | "OmsOutput" | Yes | Specifies the output type. For this output, it must be "OmsOutput". |
 | `workspaceId` | string (GUID) | Yes | Specifies the workspace identifier. |
 | `workspaceKey` | string (base-64) | Yes | Specifies the workspace authentication key. |
-| `logTypeName` | string | No | Specifies the log entry type created by the output. Default value for this setting is "Event", which results in "Event_CL" entries being created in OMS (the "_CL" suffix is appended automatically by OMS ingestion service). |
+| `logTypeName` | string | No | Specifies the log entry type created by the output. Default value for this setting is "Event", which results in "Event_CL" entries being created in OMS (the "_CL" suffix is appended automatically by OMS 
+ingestion service). |
+| `useAzureGov` | bool | No | Used to send entries to an OMS workspace located in the Azure Gov Cloud |
 
 ### Filters
 As data comes through the EventFlow pipeline, the application can add extra processing or tagging to them. These optional operations are accomplished with filters. Filters can transform, drop, or tag data with extra metadata, with rules based on custom expressions.

--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ The OMS output writes data to [Operations Management Suite](https://www.microsof
   "type": "OmsOutput",
   "workspaceId": "<workspace-GUID>",
   "workspaceKey": "<base-64-encoded workspace key>",
-  "useAzureGov" : "<optional-boolean>"
+  "serviceDomain" : "<optional domain for OMS>"
 }
 ```
 
@@ -682,7 +682,7 @@ Supported configuration settings are:
 | `workspaceKey` | string (base-64) | Yes | Specifies the workspace authentication key. |
 | `logTypeName` | string | No | Specifies the log entry type created by the output. Default value for this setting is "Event", which results in "Event_CL" entries being created in OMS (the "_CL" suffix is appended automatically by OMS 
 ingestion service). |
-| `useAzureGov` | bool | No | Used to send entries to an OMS workspace located in the Azure Gov Cloud |
+| `serviceDomain` | string | No | Specifies the domain for your OMS workspace. Default value is "ods.opinsights.azure.com", for Azure Commercial.
 
 ### Filters
 As data comes through the EventFlow pipeline, the application can add extra processing or tagging to them. These optional operations are accomplished with filters. Filters can transform, drop, or tag data with extra metadata, with rules based on custom expressions.

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Configuration/OmsOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Configuration/OmsOutputConfiguration.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
         public string WorkspaceId { get; set; }
         public string WorkspaceKey { get; set; }
         public string LogTypeName { get; set; }
+        public bool UseAzureGov { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Configuration/OmsOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Configuration/OmsOutputConfiguration.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
         public string WorkspaceId { get; set; }
         public string WorkspaceKey { get; set; }
         public string LogTypeName { get; set; }
-        public bool UseAzureGov { get; set; }
+        public string ServiceDomain { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Oms</AssemblyName>
     <AssemblyOriginatorKeyFile>../../PublicKey.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <VersionPrefix>1.1.2</VersionPrefix>
+    <VersionPrefix>1.1.3</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.Oms</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Microsoft Operations Management</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
@@ -83,7 +83,15 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
 
             var retryHandler = new HttpExponentialRetryMessageHandler();
             var httpClient = new HttpClient(retryHandler);
-            httpClient.BaseAddress = new Uri($"https://{workspaceId}.ods.opinsights.azure.com", UriKind.Absolute);
+
+            if (configuration.UseAzureGov)
+            {
+                httpClient.BaseAddress = new Uri($"https://{workspaceId}.ods.opinsights.azure.us", UriKind.Absolute);
+            }
+            else
+            {
+                httpClient.BaseAddress = new Uri($"https://{workspaceId}.ods.opinsights.azure.com", UriKind.Absolute);
+            }            
 
             string logTypeName = configuration.LogTypeName;
             if (string.IsNullOrWhiteSpace(logTypeName))

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
@@ -84,9 +84,9 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             var retryHandler = new HttpExponentialRetryMessageHandler();
             var httpClient = new HttpClient(retryHandler);
 
-            if (configuration.UseAzureGov)
+            if (!string.IsNullOrWhiteSpace(configuration.ServiceDomain))
             {
-                httpClient.BaseAddress = new Uri($"https://{workspaceId}.ods.opinsights.azure.us", UriKind.Absolute);
+                httpClient.BaseAddress = new Uri($"https://{workspaceId}." + configuration.ServiceDomain, UriKind.Absolute);
             }
             else
             {


### PR DESCRIPTION
I have a need to use EventFlow to send EventSource data from a Service Fabric application to Log Analytics in OMS. My specific OMS workspace lives in Azure's US Government Cloud. 

Based on the documentation [here](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-monitoringandmanagement) the endpoints for the OMS API are slightly different for Gov cloud.

I added a new config setting for "UseAzureGov" as a boolean. This is used simply to switch the base API url from commercial to gov. No other changes are needed to make this work. I also updated the README file to include documentation on the new, optional, config setting.

I've ran all of the scripts requested in the guidelines. I've also built the Output.OMS DLL locally and tested that I do, in fact, get log entries in my gov OMS subscription.