### PR TITLE
Add support for metricNameProperty to metric metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,12 +812,14 @@ Metrics are named time series of floating-point values. Metric metadata defines 
 | Field | Values/Types | Required | Description |
 | :---- | :-------------- | :------: | :---------- |
 | `metadata` | "metric" | Yes | Indicates metric metadata definition; must be "metric". |
-| `metricName` | string | Yes | The name of the metric. |
+| `metricName` | string | (see Remarks) | The name of the metric. |
+| `metricNameProperty` | string | (see Remarks) | The name of the event property that holds metric name. |
 | `metricValue` | double | (see Remarks) | The value of the metric. This is useful for "counter" type of metric when each occurrence of a particular event should result in an increment of the counter. |
 | `metricValueProperty` | string | (see Remarks) | The name of the event property that holds the metric value. | 
 
 Remarks: 
-1. Either `metricValue` or `metricValueProperty` must be specified.
+1. Either `metricName` or `metricNameProperty` must be specified.
+2. Either `metricValue` or `metricValueProperty` must be specified.
 
 **Request metadata type**
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/MetricData.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/Metadata/MetricData.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Diagnostics.EventFlow.Metadata
     {
         public static readonly string MetricMetadataKind = "metric";
         public static readonly string MetricNameMoniker = "metricName";
+        public static readonly string MetricNamePropertyMoniker = "metricNameProperty";
         public static readonly string MetricValueMoniker = "metricValue";
         public static readonly string MetricValuePropertyMoniker = "metricValueProperty";
 
@@ -31,10 +32,23 @@ namespace Microsoft.Diagnostics.EventFlow.Metadata
                 return DataRetrievalResult.InvalidMetadataType(metricMetadata.MetadataType, MetricMetadataKind);
             }
 
-            string metricName = metricMetadata[MetricNameMoniker];
-            if (string.IsNullOrEmpty(metricName))
+            string metricName = string.Empty;
+
+            string metricNameProperty = metricMetadata[MetricNamePropertyMoniker];
+            if (string.IsNullOrEmpty(metricNameProperty))
             {
-                return DataRetrievalResult.MissingMetadataProperty(MetricNameMoniker);
+                metricName = metricMetadata[MetricNameMoniker];
+                if (string.IsNullOrEmpty(metricName))
+                {
+                    return DataRetrievalResult.MissingMetadataProperty(MetricNameMoniker);
+                }
+            }
+            else
+            {
+                if (!eventData.GetValueFromPayload<string>(metricNameProperty, (v) => metricName = v))
+                {
+                    return DataRetrievalResult.DataMissingOrInvalid(metricNameProperty);
+                }
             }
 
             double value = 0.0;

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.10</VersionPrefix>
+    <VersionPrefix>1.1.11</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <DelaySign>true</DelaySign>


### PR DESCRIPTION
Addresses issue #136.

Add support for setting metric name from an event property, similar to setting requests with 'requestNameProperty'.