### PR TITLE
Add custom http headers support

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Configuration/HttpOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Configuration/HttpOutputConfiguration.cs
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Diagnostics.EventFlow.Configuration
 {
     // !!ACTION!!
@@ -16,11 +18,13 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
         public string HttpContentType { get; set; }
         public string BasicAuthenticationUserName { get; set; }
         public string BasicAuthenticationUserPassword { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
 
         public HttpOutputConfiguration()
         {
             Format = DefaultFormat;
             HttpContentType = "application/json";
+            Headers = new Dictionary<string, string>();
         }
 
         public HttpOutputConfiguration DeepClone()
@@ -31,7 +35,8 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
                 Format = this.Format,
                 HttpContentType = this.HttpContentType,
                 BasicAuthenticationUserName = this.BasicAuthenticationUserName,
-                BasicAuthenticationUserPassword = this.BasicAuthenticationUserPassword
+                BasicAuthenticationUserPassword = this.BasicAuthenticationUserPassword,
+                Headers = this.Headers
             };
 
             return other;

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/HttpOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/HttpOutput.cs
@@ -103,6 +103,11 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                     }
                     break;
             }
+
+            foreach (KeyValuePair<string, string> header in configuration.Headers)
+            {
+                this.httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+            }
         }
 
         public async Task SendEventsAsync(IReadOnlyCollection<EventData> events, long transmissionSequenceNumber, CancellationToken cancellationToken)

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/HttpOutputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/HttpOutputTests.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                         ["basicAuthenticationUserName"] = "mywebuser",
                         ["basicAuthenticationUserPassword"] = "mywebpass",
                         ["httpContentType"] = "application/x-custom",
+                        ["headers"] = new Dictionary<string, string>
+                        {
+                            ["X-Foo"] = "example"
+                        }
                     }
                 }
             };
@@ -53,6 +57,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 Assert.Equal("mywebuser", httpOutputConfiguration.BasicAuthenticationUserName);
                 Assert.Equal("mywebpass", httpOutputConfiguration.BasicAuthenticationUserPassword);
                 Assert.Equal("application/x-custom", httpOutputConfiguration.HttpContentType);
+                Assert.Equal("example", httpOutputConfiguration.Headers["X-Foo"]);
             }
         }
 


### PR DESCRIPTION
Add support for custom headers via configuration:

```
    {
      "type": "Http",
      "format": "JsonLines",
      "serviceUri":  "http://localhost:8000/",
      "headers":  {
        "Foo": "bar"
      }
    }
```

will produce:
```
POST / HTTP/1.1
Host: localhost:8000
Accept: */*
Content-Type: application/json; charset=utf-8
Foo: bar
Content-Length: 1610
Expect: 100-continue

{"Timestamp":"2018-03-23T20:02:29.221087+00:00","ProviderName":"ConsoleCore","Level":3,"Keywords":0,"Payload":{"Message":"EventFlow 1 is working!","EventId":0}}
{"Timestamp":"2018-03-23T20:02:29.187359+00:00","ProviderName":"ConsoleCore","Level":3,"Keywords":0,"Payload":{"Message":"EventFlow 2 is working!","EventId":0}}
{"Timestamp":"2018-03-23T20:02:29.231347+00:00","ProviderName":"ConsoleCore","Level":3,"Keywords":0,"Payload":{"Message":"EventFlow 3 is working!","EventId":0}}
```