### PR TITLE
Update package versions

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.12</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>

--- a/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.EtwUtilities</AssemblyName>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.EtwUtilities</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Utilities;Event Tracing for Windows</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
@@ -4,7 +4,7 @@
     <Description>Provides an implementation of Application Insights telemetry processor that feeds Application Insights telemetry into EventFlow pipeline. 
     This allows sending diagnostics data from applications instrumented with Application Insights to destinations other than Application Insights service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights</AssemblyName>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFramework>net451</TargetFramework>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Etw</AssemblyName>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.Etw</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;ETW;Event Tracing for Windows</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Tracing.EventSource infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.EventSource</AssemblyName>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</AssemblyName>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;MicrosoftLogging</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing data from Windows performance counters.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFramework>net451</TargetFramework>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter</AssemblyName>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data created via Serilog library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/Microsoft.Diagnostics.EventFlow.Inputs.Trace.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/Microsoft.Diagnostics.EventFlow.Inputs.Trace.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Trace</AssemblyName>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.Trace</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;Trace</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an output implementation that sends diagnostics data to Microsoft Application Insights service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights</AssemblyName>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an output implementation that sends diagnostics data to Elasticsearch.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>2.2.2</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch</AssemblyName>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</AssemblyName>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Event Hub;Event Hubs</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</AssemblyName>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;HttpOutput</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Oms</AssemblyName>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.Oms</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Microsoft Operations Management</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.StdOutput</AssemblyName>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.StdOutput</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFramework>net451</TargetFramework>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.TableStorage</AssemblyName>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>    
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides types that simplify the use of EventFlow library by Microsoft Service Fabric services.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION
This across-the-board version update is meant to make it easier to revert to previous version in case the lack of strong-name signing of EventFlow assemblies turns out to be an issue for someone. Note that all published EventFlow assemblies are Authenticode-signed to ensure assembly origin legitimacy (Microsoft).