### PR TITLE
Add netstandard 2.0 binaries to relevant EventFlow packages

### DIFF
--- a/Warsaw.sln
+++ b/Warsaw.sln
@@ -27,12 +27,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Incubation", "Incubation", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FunctionalTests", "FunctionalTests", "{05441E68-B217-475A-8E81-DB36614D1823}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuspecs", "Nuspecs", "{3B5ED5A8-29C6-4DF3-B8E8-C422453415C5}"
-	ProjectSection(SolutionItems) = preProject
-		nuspecs\ServiceFabric\Microsoft.Diagnostics.EventFlow.ServiceFabric.nuspec = nuspecs\ServiceFabric\Microsoft.Diagnostics.EventFlow.ServiceFabric.nuspec
-		nuspecs\Suite\Microsoft.Diagnostics.EventFlow.Suite.nuspec = nuspecs\Suite\Microsoft.Diagnostics.EventFlow.Suite.nuspec
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Utilities", "Utilities", "{C0F892AE-D5F5-42FD-943C-6428CA252650}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.EventFlow.Core", "src\Microsoft.Diagnostics.EventFlow.Core\Microsoft.Diagnostics.EventFlow.Core.csproj", "{F1EF768D-9E8B-42D5-B0E1-C7EF2270C245}"

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporters/CsvHealthReporter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporters/CsvHealthReporter.cs
@@ -506,6 +506,8 @@ namespace Microsoft.Diagnostics.EventFlow.HealthReporters
             }
 #elif NETSTANDARD1_6
             basePath = Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location);
+#elif NETSTANDARD2_0
+            basePath = Path.GetDirectoryName(this.GetType().Assembly.Location);
 #endif
             this.Configuration.LogFileFolder = Path.Combine(basePath, this.Configuration.LogFileFolder);
         }

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporters/CsvHealthReporter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporters/CsvHealthReporter.cs
@@ -17,8 +17,7 @@ using Validation;
 
 #if NET451
 using System.Web;
-#endif
-#if NETSTANDARD1_6
+#else
 using System.Reflection;
 #endif
 
@@ -504,10 +503,8 @@ namespace Microsoft.Diagnostics.EventFlow.HealthReporters
             {
                 basePath = Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(this.GetType()).Location);
             }
-#elif NETSTANDARD1_6
+#else
             basePath = Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location);
-#elif NETSTANDARD2_0
-            basePath = Path.GetDirectoryName(this.GetType().Assembly.Location);
 #endif
             this.Configuration.LogFileFolder = Path.Combine(basePath, this.Configuration.LogFileFolder);
         }

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="Validation" Version="2.3.7" />
+    <PackageReference Include="Validation" Version="2.4.18" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="Validation" Version="2.3.7" />
   </ItemGroup>
 
@@ -38,18 +39,9 @@
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <Reference Include="System.Web" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Core</PackageId>
@@ -13,7 +13,8 @@
     <PackageProjectUrl>https://github.com/Azure/diagnostics-eventflow</PackageProjectUrl>
     <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -38,6 +39,13 @@
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -26,9 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
@@ -39,6 +36,15 @@
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -51,6 +51,9 @@
     <Reference Include="System.Web" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
@@ -4,17 +4,18 @@
     <Description>Provides utility classes for processing data from Event Tracing for Windows (ETW) providers.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.EtwUtilities</AssemblyName>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.EtwUtilities</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Utilities;Event Tracing for Windows</PackageTags>
     <PackageProjectUrl>https://github.com/Azure/diagnostics-eventflow</PackageProjectUrl>
     <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -22,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an implementation of Application Insights telemetry processor that feeds Application Insights telemetry into EventFlow pipeline. 
     This allows sending diagnostics data from applications instrumented with Application Insights to destinations other than Application Insights service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights</PackageId>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>    

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Tracing.EventSource infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.EventSource</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.EventSource</PackageId>
@@ -13,7 +13,8 @@
     <PackageProjectUrl>https://github.com/Azure/diagnostics-eventflow</PackageProjectUrl>
     <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -26,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</AssemblyName>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;MicrosoftLogging</PackageTags>
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\Microsoft.Diagnostics.EventFlow.Core\Microsoft.Diagnostics.EventFlow.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' Or '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
   </ItemGroup>
 
@@ -36,7 +36,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
@@ -4,7 +4,7 @@
     <Description>Provides an input implementation for capturing diagnostics data sourced through Microsoft.Extensions.Logging.ILogger</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</AssemblyName>
     <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -13,7 +13,8 @@
     <PackageProjectUrl>https://github.com/Azure/diagnostics-eventflow</PackageProjectUrl>
     <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -24,13 +25,18 @@
     <ProjectReference Include="..\Microsoft.Diagnostics.EventFlow.Core\Microsoft.Diagnostics.EventFlow.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data created via Serilog library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>1.3.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Serilog</AssemblyName>
@@ -17,6 +17,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/Microsoft.Diagnostics.EventFlow.Inputs.Trace.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/Microsoft.Diagnostics.EventFlow.Inputs.Trace.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Trace infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Trace</AssemblyName>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.Trace</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;Trace</PackageTags>
@@ -15,6 +15,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -25,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides an output implementation that sends diagnostics data to Microsoft Application Insights service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights</PackageId>
@@ -13,7 +13,8 @@
     <PackageProjectUrl>https://github.com/Azure/diagnostics-eventflow</PackageProjectUrl>
     <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -24,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides an output implementation that sends diagnostics data to Elasticsearch.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch</PackageId>
@@ -14,7 +14,8 @@
     <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="Validation" Version="2.3.7" />
+    <PackageReference Include="Validation" Version="2.4.18" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Validation" Version="2.3.7" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.1" />

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
@@ -4,16 +4,17 @@
     <Description>Provides an output implementation that sends diagnostics data to Azure Event Hubs.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</AssemblyName>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Event Hub;Event Hubs</PackageTags>
     <PackageProjectUrl>https://github.com/Azure/diagnostics-eventflow</PackageProjectUrl>
     <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/HttpOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/HttpOutput.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
 
                 HttpResponseMessage response = await httpClient.PostAsync(new Uri(configuration.ServiceUri), contentPost);
                 response.EnsureSuccessStatusCode();
+                this.healthReporter.ReportHealthy();
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
@@ -4,7 +4,7 @@
     <Description>Provides an output implementation that sends diagnostics data to webserver using HTTP.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</AssemblyName>
     <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -15,6 +15,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</AssemblyName>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;HttpOutput</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -4,7 +4,7 @@
     <Description>Provides an output implementation that sends diagnostics data to Microsoft Operations Management Suite.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Oms</AssemblyName>
     <VersionPrefix>1.3.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -15,6 +15,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Oms</AssemblyName>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.Oms</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Microsoft Operations Management</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an output implementation that sends diagnostics data to standard output stream (useful for debugging purposes).</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.StdOutput</AssemblyName>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.StdOutput</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs</PackageTags>
@@ -15,6 +15,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides types that simplify the use of EventFlow library by Microsoft Service Fabric services.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
@@ -26,13 +26,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" Version="6.1.456" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Diagnostics.EventFlow.Signing/Microsoft.Diagnostics.EventFlow.Signing.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Signing/Microsoft.Diagnostics.EventFlow.Signing.csproj
@@ -91,11 +91,14 @@
                                ..\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch\bin\$(Configuration)\netstandard1.6\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.dll;
                                ..\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\bin\$(Configuration)\netstandard1.6\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.dll;
                                ..\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\bin\$(Configuration)\netstandard1.6\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Outputs.Oms\bin\$(Configuration)\netstandard1.6\Microsoft.Diagnostics.EventFlow.Outputs.Oms.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Outputs.Oms\bin\$(Configuration)\netstandard1.6\Microsoft.Diagnostics.EventFlow.Outputs.Oms.dll;" />
+      <NetStandard20Assemblies Include="..\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.EventFlow.Core.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.dll;
                                ..\Microsoft.Diagnostics.EventFlow.ServiceFabric\bin\$(Configuration)\netstandard2.0\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll;" />
     </ItemGroup>
     <Move SourceFiles="@(FullAssemblies)" DestinationFolder="$(OutputPath)\full" />
     <Move SourceFiles="@(CoreAssemblies)" DestinationFolder="$(OutputPath)\core" />
+    <Move SourceFiles="@(NetStandard20Assemblies)" DestinationFolder="$(OutputPath)\netstandard2.0" />
   </Target>
   <ItemGroup>
     <!--We can't use wildcard here since it's expanded before build, which is empty.-->
@@ -127,7 +130,9 @@
                           $(OutputPath)\core\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.dll;
                           $(OutputPath)\core\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.dll;
                           $(OutputPath)\core\Microsoft.Diagnostics.EventFlow.Outputs.Oms.dll;
-                          $(OutputPath)\core\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll;">
+                          $(OutputPath)\netstandard2.0\Microsoft.Diagnostics.EventFlow.Core.dll;
+                          $(OutputPath)\netstandard2.0\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.dll;
+                          $(OutputPath)\netstandard2.0\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll;">
       <Authenticode>Microsoft</Authenticode>
       <StrongName>StrongName</StrongName>
     </FilesToSign>
@@ -163,7 +168,9 @@
     <Copy SourceFiles="$(OutputPath)\core\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\bin\$(Configuration)\netstandard1.6"/>
     <Copy SourceFiles="$(OutputPath)\core\Microsoft.Diagnostics.EventFlow.Outputs.Oms.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.Oms\bin\$(Configuration)\netstandard1.6"/>
     <Copy SourceFiles="$(OutputPath)\core\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\bin\$(Configuration)\netstandard1.6"/>
-    <Copy SourceFiles="$(OutputPath)\core\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.ServiceFabric\bin\$(Configuration)\netstandard2.0"/>
+    <Copy SourceFiles="$(OutputPath)\netstandard2.0\Microsoft.Diagnostics.EventFlow.Core.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\netstandard2.0"/>
+    <Copy SourceFiles="$(OutputPath)\netstandard2.0\Microsoft.Diagnostics.EventFlow.MicrosoftLogging.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.MicrosoftLogging\bin\$(Configuration)\netstandard2.0"/>
+    <Copy SourceFiles="$(OutputPath)\netstandard2.0\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.ServiceFabric\bin\$(Configuration)\netstandard2.0"/>
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Microsoft.Diagnostics.EventFlow.Signing/Microsoft.Diagnostics.EventFlow.Signing.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Signing/Microsoft.Diagnostics.EventFlow.Signing.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
+  <Import Project="..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props" Condition="Exists('..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -45,10 +45,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
-    <Error Condition="!Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props'))" />
+    <Error Condition="!Exists('..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.targets'))" />
   </Target>
-  <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
+  <Import Project="..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.targets')" />
 
   <!--
     Remove TraceEvent native binaries that are not really needed-the Etw input Nuget package depends on TraceEvent Nuget package

--- a/src/Microsoft.Diagnostics.EventFlow.Signing/packages.config
+++ b/src/Microsoft.Diagnostics.EventFlow.Signing/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MicroBuild.Core" version="0.2.0" targetFramework="net452" developmentDependency="true" />
+  <package id="MicroBuild.Core" version="0.3.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
@@ -35,12 +35,20 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Elasticsearch.Net" Version="6.0.2" />
-    <PackageReference Include="NEST" Version="6.0.2" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.0.2" />
+    <PackageReference Include="NEST" Version="6.0.2" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net46;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-     <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;net46</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -30,11 +30,10 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.6" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net46;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />    
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -28,7 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />    
     <PackageReference Include="Moq" Version="4.8.2" />

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/test/TestHelpers/TestHelpers.csproj
+++ b/test/TestHelpers/TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.TestHelpers</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <NoWarn>$(NoWarn);NU1603</NoWarn>


### PR DESCRIPTION
Should fix the following issues:

https://github.com/Azure/diagnostics-eventflow/issues/171
https://github.com/Azure/diagnostics-eventflow/issues/182
https://github.com/Azure/diagnostics-eventflow/issues/208
