### PR TITLE
Add process info to Etw event payload

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/TraceEventExtensions.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             {
                 payloadData.Add(nameof(traceEvent.RelatedActivityID), traceEvent.RelatedActivityID.ToString());
             }
+            payloadData.Add(nameof(traceEvent.ProcessID), traceEvent.ProcessID);
+            payloadData.Add(nameof(traceEvent.ProcessName), traceEvent.ProcessName);
 
             try
             {


### PR DESCRIPTION
The Etw [TraceEvent](https://github.com/Microsoft/perfview/blob/master/src/TraceEvent/TraceEvent.cs) contains [ProcessID](https://github.com/Microsoft/perfview/blob/master/src/TraceEvent/TraceEvent.cs#L739) and [ProcessName](https://github.com/Microsoft/perfview/blob/dcece4936e6c8c60073eddd2213b00bca83aab69/src/TraceEvent/TraceEvent.cs#L754) properties. Having access to the process data seems important to me 😄.

This PR simply adds these two property values to the payload.