### PR TITLE
Add support for expressing keywords in hex format

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/ConfigUtil.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/ConfigUtil.cs
@@ -1,0 +1,41 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow.Utilities.Etw
+{
+    public static class ConfigUtil
+    {
+        /// <summary>
+        /// Converts Keywords property value from hexadecimal notation to decimal notation
+        /// </summary>
+        /// <param name="configuration">Configuration instance to process (a list of records)</param>
+        /// <remarks>Configuration binder cannot parse hexadecimal notation, which is very useful for Keywords. 
+        /// So as a workaround, we convert the value to decimal notation before passing the configuration to the binder.
+        /// </remarks>
+        public static void ConvertKeywordsToDecimal(IConfiguration configuration)
+        {
+            Requires.NotNull(configuration, nameof(configuration));
+
+            foreach (var record in configuration.GetChildren())
+            {
+                var keywordsStr = record["Keywords"];
+                if (string.IsNullOrEmpty(keywordsStr)) continue;
+
+                keywordsStr = keywordsStr.TrimStart(null); // Null means "remove whitespace"
+                if (string.IsNullOrEmpty(keywordsStr) || !keywordsStr.StartsWith("0x", StringComparison.OrdinalIgnoreCase)) continue;
+
+                // Event if HexNumber is set, the .NET Framework TryParse() methods do not allow the '0x' prefix to be part of the value.
+                if (!ulong.TryParse(keywordsStr.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ulong keywords)) continue;
+
+                record["Keywords"] = keywords.ToString("d");
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.EtwUtilities</AssemblyName>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.EtwUtilities</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Utilities;Event Tracing for Windows</PackageTags>
@@ -24,11 +24,21 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[1.1.1,2.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[1.1.1,2.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Validation" Version="2.4.18" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/EtwInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/EtwInput.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
                 return;
             }
             var providers = new List<EtwProviderConfiguration>();
+            ConfigUtil.ConvertKeywordsToDecimal(providersConfiguration);
             try
             {
                 providersConfiguration.Bind(providers);
@@ -162,11 +163,6 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
 
             this.Providers = providers;
             // The session is not started until Activate() is called.
-
-            if (providers.Count == 0)
-            {
-                healthReporter.ReportWarning($"{nameof(EtwInput)}: no providers configured, the input will not produce any data", EventFlowContextIdentifiers.Configuration);
-            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/EtwInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/EtwInput.cs
@@ -162,6 +162,11 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
 
             this.Providers = providers;
             // The session is not started until Activate() is called.
+
+            if (providers.Count == 0)
+            {
+                healthReporter.ReportWarning($"{nameof(EtwInput)}: no providers configured, the input will not produce any data", EventFlowContextIdentifiers.Configuration);
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an input implementation for capturing diagnostics data from Event Tracing for Windows (ETW) providers.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Etw</AssemblyName>
-    <VersionPrefix>1.3.3</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.Etw</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;ETW;Event Tracing for Windows</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventSourceInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventSourceInput.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
 
             if (eventSources.Count() == 0)
             {
-                healthReporter.ReportWarning($"{nameof(EventSourceInput)}: no event sources configured", EventFlowContextIdentifiers.Configuration);
+                healthReporter.ReportWarning($"{nameof(EventSourceInput)}: no event sources configured, the input will not produce any data", EventFlowContextIdentifiers.Configuration);
             }
 
             var invalidConfigurationItems = new List<EventSourceConfiguration>();

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventSourceInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventSourceInput.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
                 return;
             }
             var eventSources = new List<EventSourceConfiguration>();
+            ConfigUtil.ConvertKeywordsToDecimal(sourcesConfiguration);
             try
             {
                 sourcesConfiguration.Bind(eventSources);

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DiagnosticsPipelineFactoryTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DiagnosticsPipelineFactoryTests.cs
@@ -459,7 +459,6 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
 
         private static async void TryDeleteFile(string startWith, string extension = ".csv", int delayMilliseconds = 0)
         {
-            // Clean up
             await Task.Delay(delayMilliseconds);
             string[] targets = Directory.GetFiles(Directory.GetCurrentDirectory(), $"{startWith}*{extension}");
             foreach (string file in targets)

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -22,14 +22,22 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Serilog\Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Etw\Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Etw\Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.11" />
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">    
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[1.1.1,2.0)" />
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.CSharp" />    
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[1.1.1,2.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,6 +49,8 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.11" />
+    <PackageReference Include="System.Reflection.Metadata" Version="[1.5.0,1.6.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/TestTraceEventSession.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/TestTraceEventSession.cs
@@ -5,7 +5,6 @@
 
 namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
 {
-#if NET46
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -121,5 +120,4 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
             this.ReportEvent(e);
         }
     }
-#endif
 }


### PR DESCRIPTION
Resolves issue https://github.com/Azure/diagnostics-eventflow/issues/231
Resolves issue https://github.com/Azure/diagnostics-eventflow/issues/242
Re-enables ETW input tests