### PR TITLE
Improve handling of property name conflicts

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/PayloadDictionaryUtilities.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/PayloadDictionaryUtilities.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Diagnostics.EventFlow
 {
     public static class PayloadDictionaryUtilities
     {
-        private static Lazy<Random> random = new Lazy<Random>();
-
         public static void AddPayloadProperty(IDictionary<string, object> payload, string key, object value, IHealthReporter healthReporter, string context)
         {
             Requires.NotNull(payload, nameof(payload));
@@ -24,11 +22,13 @@ namespace Microsoft.Diagnostics.EventFlow
                 return;
             }
 
-            string newKey = key + "_";
+            string newKey;
+            int i = 1;
             //update property key till there is no such key in dict
             do
             {
-                newKey += PayloadDictionaryUtilities.random.Value.Next(0, 10);
+                newKey = key + "_" + i.ToString("d");
+                i++;
             }
             while (payload.ContainsKey(newKey));
 

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.4.1</VersionPrefix>
+    <VersionPrefix>1.4.2</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Etw</AssemblyName>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.4.1</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.Etw</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;ETW;Event Tracing for Windows</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/TraceEventExtensions.cs
@@ -38,8 +38,9 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             {
                 payloadData.Add(nameof(traceEvent.RelatedActivityID), traceEvent.RelatedActivityID.ToString());
             }
-            payloadData.Add(nameof(traceEvent.ProcessID), traceEvent.ProcessID);
-            payloadData.Add(nameof(traceEvent.ProcessName), traceEvent.ProcessName);
+            // ProcessID and ProcessName are somewhat common property names, so to minimize likelihood of conflicts we use a prefix
+            payloadData.Add("TraceEventProcessID", traceEvent.ProcessID);
+            payloadData.Add("TraceEventProcessName", traceEvent.ProcessName);
 
             try
             {


### PR DESCRIPTION
1. Make de-conflicted property names more predictable
2. Reduce likelihood of property name conflicts for ETW input