### PR TITLE
Avoid adding duplicate equivalent payload properties

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/PayloadDictionaryUtilities.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/PayloadDictionaryUtilities.cs
@@ -16,24 +16,40 @@ namespace Microsoft.Diagnostics.EventFlow
             Requires.NotNull(key, nameof(key));
             Requires.NotNull(healthReporter, nameof(healthReporter));
 
-            if (!payload.ContainsKey(key))
+            if (!payload.TryGetValue(key, out var existingValue))
             {
                 payload.Add(key, value);
+                return;
+            }
+            else if ((existingValue?.Equals(value)).GetValueOrDefault(false))
+            {
+                // Existing value with same key is equivalent to the input value
+                // We can return immediately to avoid adding duplicate key/value into the payload
+                healthReporter.ReportWarning($"The property with the key '{key}' already exist in the event payload with equivalent value. Value was not re-added", context);
                 return;
             }
 
             string newKey;
             int i = 1;
+
             //update property key till there is no such key in dict
             do
             {
                 newKey = key + "_" + i.ToString("d");
                 i++;
             }
-            while (payload.ContainsKey(newKey));
+            while (payload.TryGetValue(newKey, out existingValue) && !(existingValue?.Equals(value)).GetValueOrDefault(false));
 
-            payload.Add(newKey, value);
-            healthReporter.ReportWarning($"The property with the key '{key}' already exist in the event payload. Value was added under key '{newKey}'", context);
+            if (!payload.ContainsKey(newKey))
+            {
+                payload.Add(newKey, value);
+                healthReporter.ReportWarning($"The property with the key '{key}' already exist in the event payload. Value was added under key '{newKey}'", context);
+            }
+            else
+            {
+                healthReporter.ReportWarning($"The property with the key '{key}' already exist in the event payload with equivalent value under key '{newKey}'. Value was not re-added", context);
+                return;
+            }
         }
     }
 }

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/EventDataTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/EventDataTests.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using Moq;
 using System.Reflection;
 using Xunit;
 
@@ -35,6 +36,93 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
             object value;
             Assert.True(data.TryGetPropertyValue("prop", out value));
             Assert.Equal("value", value);
+        }
+
+        [Fact]
+        public void AddPayloadPropertyDoesNotAddDuplicatesIfKeyAndValueEquals()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var data = new EventData();
+            data.AddPayloadProperty("prop", "value", healthReporterMock.Object, "tests");
+            data.AddPayloadProperty("prop", "value", healthReporterMock.Object, "tests");
+
+            Assert.Equal(1, data.Payload.Keys.Count);
+            object value;
+            Assert.True(data.TryGetPropertyValue("prop", out value));
+            Assert.Equal("value", value);
+            healthReporterMock.Verify(m => m.ReportWarning(It.Is<string>(s => s.StartsWith("The property with the key 'prop' already exist in the event payload with equivalent value")), It.IsIn("tests")));
+        }
+
+        [Fact]
+        public void AddPayloadPropertyDoesNotAddDuplicatesIfKeyAndValueEqualsAtIndexedValues()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var data = new EventData();
+            data.AddPayloadProperty("prop", "value1", healthReporterMock.Object, "tests");
+            data.AddPayloadProperty("prop", "value2", healthReporterMock.Object, "tests");
+            data.AddPayloadProperty("prop", "value3", healthReporterMock.Object, "tests");
+            data.AddPayloadProperty("prop", "value3", healthReporterMock.Object, "tests");
+
+            Assert.Equal(3, data.Payload.Keys.Count);
+            object value;
+            Assert.True(data.TryGetPropertyValue("prop", out value));
+            Assert.Equal("value1", value);
+            Assert.True(data.TryGetPropertyValue("prop_1", out value));
+            Assert.Equal("value2", value);
+            Assert.True(data.TryGetPropertyValue("prop_2", out value));
+            Assert.Equal("value3", value);
+            healthReporterMock.Verify(m => m.ReportWarning(It.Is<string>(s => s.StartsWith("The property with the key 'prop' already exist in the event payload with equivalent value under key 'prop_2'")), It.IsIn("tests")));
+        }
+
+        [Fact]
+        public void AddPayloadPropertyAddsIndexedValuesIfKeyEqualsButValueDiffers()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var data = new EventData();
+            data.AddPayloadProperty("prop", "value1", healthReporterMock.Object, "tests");
+            data.AddPayloadProperty("prop", "value2", healthReporterMock.Object, "tests");
+
+            Assert.Equal(2, data.Payload.Keys.Count);
+            object value;
+            Assert.True(data.TryGetPropertyValue("prop", out value));
+            Assert.Equal("value1", value);
+
+            Assert.True(data.TryGetPropertyValue("prop_1", out value));
+            Assert.Equal("value2", value);
+        }
+
+        [Fact]
+        public void AddPayloadPropertyAddsIndexedValuesIfKeyEqualsButInitialValueIsNull()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var data = new EventData();
+            data.AddPayloadProperty("prop", null, healthReporterMock.Object, "tests");
+            data.AddPayloadProperty("prop", "value2", healthReporterMock.Object, "tests");
+
+            Assert.Equal(2, data.Payload.Keys.Count);
+            object value;
+            Assert.True(data.TryGetPropertyValue("prop", out value));
+            Assert.Null(value);
+
+            Assert.True(data.TryGetPropertyValue("prop_1", out value));
+            Assert.Equal("value2", value);
+        }
+
+        [Fact]
+        public void AddPayloadPropertyAddsIndexedValuesIfKeyEqualsButSecondValueIsNull()
+        {
+            var healthReporterMock = new Mock<IHealthReporter>();
+            var data = new EventData();
+            data.AddPayloadProperty("prop", "value1", healthReporterMock.Object, "tests");
+            data.AddPayloadProperty("prop", null, healthReporterMock.Object, "tests");
+
+            Assert.Equal(2, data.Payload.Keys.Count);
+            object value;
+            Assert.True(data.TryGetPropertyValue("prop", out value));
+            Assert.Equal("value1", value);
+
+            Assert.True(data.TryGetPropertyValue("prop_1", out value));
+            Assert.Null(value);
         }
     }
 }


### PR DESCRIPTION
Fixes:  #269 

When duplicate payload properties are added, if the new value equals the existing value then it's not added to the payload at all and a health warning is written.