### PR TITLE
Add support for shared file folder for CsvHealthReporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,7 +1031,8 @@ This health reporter writes all errors, warnings, and informational traces gener
     "throttlingPeriodMsec": "1000",
     "singleLogFileMaximumSizeInMBytes": "8192",
     "logRetentionInDays": "30",
-    "ensureOutputCanBeSaved": "false"
+    "ensureOutputCanBeSaved": "false",
+    "assumeSharedLogFolder": "false"
 }
 ```
 | Field | Values/Types | Required | Description |
@@ -1043,7 +1044,8 @@ This health reporter writes all errors, warnings, and informational traces gener
 | `throttlingPeriodMsec` | number of milliseconds | No | Specifies the throttling time period. This setting protects the health reporter from being overwhelmed, which can happen if a message is repeatedly generated due to an error in the pipeline. Default is 0, for no throttling. |
 | `singleLogFileMaximumSizeInMBytes` | File size in MB/number | No | Specifies the size of the log file in MB before rotating happens. The default value is 8192 MB (8 GB). Once the size of log file exceeds the value, it will be renamed from fileName.csv to fileName_last.csv. Then logs will be written to a new fileName.csv. This setting prevents a single log file become too big. |
 | `logRetentionInDays` | number of days for the logs files retain | No | Specifies how long log files will be retained. The default value is 30 days. Any log files created earlier than the specified number of days ago will be removed automatically. This prevents continuous generation of logs that might lead to storage exhaustion. |
-| `ensureOutputCanBeSaved` | boolean | No | Specifies whether the health reporter is going to ensure the permission to write to the log folder. The default value is `false`. When set to `true`, it will prevent the pipeline creation when it can't write the log. Otherwise, it will ignore the error.
+| `ensureOutputCanBeSaved` | boolean | No | Specifies whether the health reporter is going to ensure the permission to write to the log folder. The default value is `false`. When set to `true`, it will prevent the pipeline creation when it can't write the log. Otherwise, it will ignore the error. |
+| `assumeSharedLogFolder` | boolean | No | Specifies whether the health reporter will use a random string in attempt to make the health reporter file unique. This is useful if multiple processes using EventFlow use the same folder to store their health reporter files. Default value is `false`. |
 
 CsvHealthReporter will try to open the log file for writing during initialization. If it can't, by default, a debug message will be output to the debugger viewer like Visual Studio Output window, etc. This can happen especially if a value for the log file path is not provided (default is used, which is application executables folder) and the application executables are residing on a read-only file system. Docker tools for Visual Studio use this configuration during debugging, so for containerized services the recommended practice is to specify the log file path explicitly.
 

--- a/src/Microsoft.Diagnostics.EventFlow.Consumers.ASPNET/Microsoft.Diagnostics.EventFlow.Consumers.ASPNET.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Consumers.ASPNET/Microsoft.Diagnostics.EventFlow.Consumers.ASPNET.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -20,16 +20,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporters/CsvHealthReporterConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporters/CsvHealthReporterConfiguration.cs
@@ -16,5 +16,6 @@ namespace Microsoft.Diagnostics.EventFlow.HealthReporters
         public int SingleLogFileMaximumSizeInMBytes { get; set; }
         public int LogRetentionInDays { get; set; }
         public bool EnsureOutputCanBeSaved { get; set; }
+        public bool AssumeSharedLogFolder { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.5.1</VersionPrefix>
+    <VersionPrefix>1.5.2</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451;net471</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/CsvHealthReporterTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/CsvHealthReporterTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
         private const string SingleLogFileMaximumSizeInMBytesKey = "SingleLogFileMaximumSizeInMBytes";
         private const string LogRetentionInDaysKey = "LogRetentionInDays";
         private const string EnsureOutputCanBeSavedKey = "EnsureOutputCanBeSaved";
+        private const string AssumeSharedLogFolder = "AssumeSharedLogFolder";
         private const int StreamOperationTimeoutMsec = 500;
 
         [Fact]
@@ -480,6 +481,22 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                 Assert.False(target.EnsureOutputCanBeSaved);
             }
         }
+
+        [Fact]
+        public void ShouldRandomizeLogFileNameIfRequested()
+        {
+            var configuration = BuildTestConfigration();
+            configuration[AssumeSharedLogFolder] = "true";
+            configuration[LogFileFolderKey] = "/log/folder";
+            DateTime now = DateTime.Now;
+
+            using (SharedFolderTestHealthReporter reporter = new SharedFolderTestHealthReporter(configuration))
+            {
+                reporter.Activate();
+                // Expect "HealthReporter_", followed by 12-char randomizer string, followed by underscore, followed by date in yyyymmdd format, followed by ".csv"
+                Assert.Matches($"{DefaultReporterPrefix}_[a-zA-Z0-9]{{12}}_20[0-9]{{6}}.csv", reporter.CurrentLogFilePath);
+            }
+    }
 
         private IConfiguration BuildTestConfigration(
             long? logFileMaxInMB = null,

--- a/test/TestHelpers/CustomHealthReporter.cs
+++ b/test/TestHelpers/CustomHealthReporter.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Diagnostics.EventFlow.TestHelpers
             StreamWriterMock.SetupGet(sw => sw.BaseStream).Returns(this.memoryStream);
         }
 
-        internal override void SetNewStreamWriter()
+        internal override void SetNewStreamWriter(Func<string, bool> directoryExists, Func<string, DirectoryInfo> createDirectory)
         {
             this.setStreamWriter();
         }

--- a/test/TestHelpers/SharedFolderTestHealthReporter.cs
+++ b/test/TestHelpers/SharedFolderTestHealthReporter.cs
@@ -1,0 +1,33 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.IO;
+using Microsoft.Diagnostics.EventFlow.HealthReporters;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Diagnostics.EventFlow.TestHelpers
+{
+    public class SharedFolderTestHealthReporter : CsvHealthReporter
+    {
+        public string CurrentLogFilePath { get; private set; }
+
+        public SharedFolderTestHealthReporter(IConfiguration configuration)
+            : base(configuration.ToCsvHealthReporterConfiguration())
+        {
+        }
+
+        internal override FileStream CreateFileStream(string logFilePath)
+        {
+            CurrentLogFilePath = logFilePath;
+            return null;
+        }
+
+        internal override void SetNewStreamWriter(Func<string, bool> directoryExists, Func<string, DirectoryInfo> createDirectory)
+        {
+            base.SetNewStreamWriter(path => true, newDirPath => null);
+        }
+    }
+}


### PR DESCRIPTION
Some customers have trouble setting up EventFlow when CsvHealthReporters from multiple service instances are writing to the same folder: https://github.com/Azure/diagnostics-eventflow/issues/175#issuecomment-430624335

Also upgrades one sample project to take advantage of security fixes in ASP.NET Core.