### PR TITLE
Added output dynatrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It runs in the same process as the application, so communication overhead is min
 - [Azure EventHub](#event-hub)
 - [Elasticsearch](#elasticsearch)
 - [OMS (Operations Management Suite)](#oms-operations-management-suite)
+- [Dynatrace](#dynatrace)
 
 The EventFlow suite supports .NET applications and .NET Core applications. It allows diagnostic data to be collected and transferred for applications running in these Azure environments:
 
@@ -862,6 +863,85 @@ Supported configuration settings are:
 ingestion service). |
 | `serviceDomain` | string | No | Specifies the domain for your OMS workspace. Default value is "ods.opinsights.azure.com", for Azure Commercial.
 
+#### Dynatrace 
+
+*Nuget package*: [**Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace**](https://www.nuget.org/packages/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/)
+
+The Dynatrace output writes data to [Dynatrace](https://www.dynatrace.com) tenants. You will need to create a Dynatrace account and know its tenant and api-token before using Dynatrace output. Here is a sample configuration fragment enabling the output:
+```json
+{
+
+    "type": "Dynatrace",
+    "APIToken": "<YOUR API TOKEN>",
+    "ServiceBaseAddress": "https://<YOUR-TENANT-ID>.live.dynatrace.com",
+    "ServiceAPIEndpoint": "/api/",
+    "MonitoredEntity": {
+        "entityAlias": "ServiceFabric Cluster",
+        "displayName": "ServiceFabric Cluster",
+        "type": "ServiceFabric",
+        "ipAddresses": [ "azure-metadata" ],
+        "listenPorts": [ "8080" ],
+        "tags": [ "ServiceFabric" ],
+        "configUrl": "http://localhost:19080",
+        "favicon": "https://assets.dynatrace.com/global/icons/white/icons_technologies_003_microsoft-azure-fabric.png",
+        "Timeseries": {
+            "timeseriesID": "servicefabric.events",
+            "displayName": "ServiceFabric Events",
+            "unit": "Count",
+            "dimensions": [ "channel", "event" ],
+            "types": [ "ServiceFabric" ]
+        }
+    } 
+    
+}
+```
+
+Supported configuration settings are:
+
+| Field | Values/Types | Required | Description |
+| :---- | :-------------- | :------: | :---------- |
+| `type` | "Dynatrace" | Yes | Specifies the output type. For this output, it must be "Dynatrace". |
+| `APIToken` | string (GUID) | Yes | Specifies the Dynatrace API Token |
+| `ServiceBaseAddress` | string | Yes | Specifies the API base address for your tenant |
+| `entityAlias` | string | Yes | Either a custom name or in case of Azure Virtual Machine "azure-metadata" to capture the name from the Azure VM |
+| `ipAddresses` | string | Yes | Either the entities ip-adress(es) or in case of Azure Virtual Machine "azure-metadata" to retrieve the ip-addresses from the Azure VM |
+| `listenPorts` | string | Yes | Ports used by the servicefabric services |
+| `configUrl` | string | true | Should be the endpoint of ServiceFabric Explorer, so Dynatrace automatically links from Dynatrace UI into SF explorer |
+| `Timeseries` | object | false | If defined, event statistics are tracked as a custom timeseries based on "ProviderName" and "Event-ID" |
+
+For more information about how to use Metrics in Dynatrace see [**Dynatrace Device Metrics**](https://www.dynatrace.com/support/help/dynatrace-api/environment/timeseries-api/manage-custom-metrics-via-api/)
+
+
+*Metadata support*
+
+Dynatrace output supports the standard "metric" metadata. 
+Additionally the "dynatrace-event" metadata type is available to customize how the event is sent to dynatrace. 
+
+| Field | Values/Types | Required | Description |
+| :---- | :-------------- | :------: | :---------- |
+| `metadata` | "dynatrace-event" | false | Indicates Dynatrace event metadata; must be "dynatrace-event". |
+| `source` | string | false | Overrides the "source" property of the event (default is "eventflow") |
+| `eventType` | string | false | Overrides the "eventType" property of the event (default is "CUSTOM_ANNOTATION") |
+| `annotationType` | string | false | Overrides the "annotationType" property of the event (default is "{eventName} - {eventID}") |
+| `annotationTypeProperty` | string | false | Maps an incoming event-property to "annotationType" property  |
+| `annotationDescription` | string | false | Overrides the "annotationDescription" property of the event (default is "{eventMessage}") |
+| `annotationDescriptionProperty` | string | false | Maps an incoming event-property to "annotationDescription" property |
+| `description` | string | false | Sets the "description" property of the incoming event |
+| `descriptionProperty` | string | false | Maps an incoming event-property to "description" property  |
+| `deploymentName` | string | false | Sets the "deploymentName" property of the event
+| `deploymentNameProperty` | string | false | Maps an incoming event-property to "deploymentName" property
+| `deploymentVersion` | string | false | Sets the "deploymentVersion" property of the event
+| `deploymentVersionProperty` | string | false | Maps an incoming event-property to "deploymentVersion" property
+| `configuration` | string | false | Sets the "configuration" property of the event
+| `configurationProperty` | string | false | Maps an incoming event-property to "configuration" property
+| `tagMatchEntityType` | string | false | filters matching entities by entity-type e.g. "HOST" [read more](https://www.dynatrace.com/support/help/dynatrace-api/environment/events-api/#events-post-parameter-taginfo)
+| `tagMatchContext` | string | true | Filters matching tags by context. e.g. "CONTEXTLESS" matching entities by entity-type e.g. "HOST" [read more](https://www.dynatrace.com/support/help/dynatrace-api/environment/events-api/#events-post-parameter-enum-gWW16rUCfKLr7Ud9I1FpMA)
+| `tagMatchKey` | string | false | Sets the matching tag-key 
+| `tagMatchValue` | string | true | Sets the matching tag-value 
+| `tagMatchValueProperty` | string | true | Maps an incoming event-property to match a tag-value 
+
+For more information about how to use the event properties see [**Dynatrace Event API**](https://www.dynatrace.com/support/help/shortlink/api-events#events-post-parameter-eventpushmessage)
+
 ### Filters
 As data comes through the EventFlow pipeline, the application can add extra processing or tagging to them. These optional operations are accomplished with filters. Filters can transform, drop, or tag data with extra metadata, with rules based on custom expressions.
 With metadata tags, filters and outputs operating further down the pipeline can apply different processing for different data. For example, an output component can choose to send only data with a certain tag. Each filter type has its own set of parameters.
@@ -1385,6 +1465,7 @@ The following table lists platform support for standard inputs and outputs.
 | [Azure EventHub](#event-hub) | Yes | Yes | Yes |
 | [Elasticsearch](#elasticsearch) | Yes | Yes | Yes |
 | [OMS (Operations Management Suite)](#oms-operations-management-suite) | Yes | Yes | Yes |
+| [Dynatrace](#dynatrace) | Yes | Yes | Yes |
 
 ## Contributions
 Refer to [contribution guide](contributing.md).

--- a/Warsaw.sln
+++ b/Warsaw.sln
@@ -113,6 +113,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Diagnostics.Event
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource", "src\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.csproj", "{A53665AF-C4B4-4DD8-B002-F8065C1A3D10}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace", "src\Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace\Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.csproj", "{81AEC6B4-7F83-4344-8361-0AF95BD23931}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -377,6 +379,14 @@ Global
 		{A53665AF-C4B4-4DD8-B002-F8065C1A3D10}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A53665AF-C4B4-4DD8-B002-F8065C1A3D10}.Release|x64.ActiveCfg = Release|Any CPU
 		{A53665AF-C4B4-4DD8-B002-F8065C1A3D10}.Release|x64.Build.0 = Release|Any CPU
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931}.Debug|x64.Build.0 = Debug|Any CPU
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931}.Release|x64.ActiveCfg = Release|Any CPU
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -414,6 +424,7 @@ Global
 		{B19F59CA-8030-40EB-BF22-6A4B1B896C37} = {47200F40-43E1-4B09-B803-A921FED2BF05}
 		{C1CB9BDC-2F26-46AA-9F2C-F9C12E9A3418} = {FC86C736-6428-431B-B83F-940BF7182757}
 		{A53665AF-C4B4-4DD8-B002-F8065C1A3D10} = {47200F40-43E1-4B09-B803-A921FED2BF05}
+		{81AEC6B4-7F83-4344-8361-0AF95BD23931} = {5AD3BB0F-B6F8-4361-AC2D-CC3514DA37A0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8F1BC23F-956D-4D83-B675-710B743F08EF}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Configuration/DynatraceOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Configuration/DynatraceOutputConfiguration.cs
@@ -1,0 +1,39 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.EventFlow.Configuration
+{
+    // !!ACTION!!
+    // If you make any changes here, please update the README.md file to reflect the new configuration
+    public class DynatraceOutputConfiguration : ItemConfiguration
+    {
+        public string ServiceBaseAddress { get; set; }
+        public string ServiceAPIEndpoint { get; set; }
+        public string APIToken { get; set; }
+
+        public MonitoredEntityConfig MonitoredEntity { get; set;}
+       
+        public DynatraceOutputConfiguration()
+        {
+            
+        }
+
+        public DynatraceOutputConfiguration DeepClone()
+        {
+            var deepCopy = new DynatraceOutputConfiguration()
+            {
+                ServiceBaseAddress = this.ServiceBaseAddress,
+                ServiceAPIEndpoint = this.ServiceAPIEndpoint,
+                APIToken = this.APIToken,
+                MonitoredEntity = new MonitoredEntityConfig(this.MonitoredEntity)
+            };
+
+            return deepCopy;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Configuration/MonitoredEntityConfig.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Configuration/MonitoredEntityConfig.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+
+    public class MonitoredEntityConfig: MonitoredEntity
+    {
+        public string resolveFromTag { get; set; }
+        public string entityAlias { get; set; }
+        public TimeseriesConfig TimeSeries { get; set; }
+    
+        public MonitoredEntityConfig()
+        { }
+        public MonitoredEntityConfig(MonitoredEntityConfig entity)
+        {
+            resolveFromTag = entity.resolveFromTag;
+            entityAlias = entity.entityAlias;
+            TimeSeries = new TimeseriesConfig(entity.TimeSeries);
+
+            displayName = entity.displayName;
+            if (entity.ipAddresses != null)
+                ipAddresses = entity.ipAddresses.Clone() as string[];
+            if (entity.listenPorts != null)
+                listenPorts = entity.listenPorts.Clone() as string[];
+            type = entity.type;
+            favicon = entity.favicon;
+            configUrl = entity.configUrl;
+            if (entity.tags != null)
+                tags = entity.tags.Clone() as string[];
+            if (entity.properties != null)
+                properties = new Dictionary<string, string>(entity.properties);
+
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Configuration/TimeseriesConfig.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Configuration/TimeseriesConfig.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class TimeseriesConfig : TimeseriesRegistrationMessage
+    {
+        public string timeseriesId { get; set; }
+        public TimeseriesConfig ()
+        {
+        }
+        public TimeseriesConfig (TimeseriesConfig  def)
+        {
+            this.timeseriesId = def.timeseriesId;
+            this.displayName = def.displayName;
+            this.unit = def.unit;
+            this.dimensions = def.dimensions.Clone() as string[];
+            this.types = def.types.Clone() as string[];
+        }
+
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/DynatraceOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/DynatraceOutput.cs
@@ -1,0 +1,563 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Configuration;
+using Validation;
+
+using Microsoft.Diagnostics.EventFlow.Configuration;
+using Microsoft.Diagnostics.EventFlow.Metadata;
+using System.Net.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model;
+using System.Text;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs
+{
+    public class DynatraceOutput : IOutput
+    {
+        private static readonly Task CompletedTask = Task.FromResult<object>(null);
+
+        private DynatraceOutputConfiguration dtOutputConfiguration;
+        private string entityID;
+
+        private HttpClient restClient;
+        private readonly IHealthReporter healthReporter;
+
+        DateTime? StartWaitMetrics = null;
+        DateTime? StartWaitEvents = null;
+
+        string EventEndoint { get { return dtOutputConfiguration.ServiceAPIEndpoint + "v1/events/"; } }
+        string TimeSeriesEndoint { get { return dtOutputConfiguration.ServiceAPIEndpoint + "v1/timeseries/"; } }
+        string MetricEndoint { get { return dtOutputConfiguration.ServiceAPIEndpoint + "v1/entity/infrastructure/"; } }
+        string HostEntityEndoint { get { return dtOutputConfiguration.ServiceAPIEndpoint + "v1/entity/infrastructure/hosts"; } }
+
+
+        public DynatraceOutput(IConfiguration configuration, IHealthReporter healthReporter)
+        {
+            Requires.NotNull(configuration, nameof(configuration));
+            Requires.NotNull(healthReporter, nameof(healthReporter));
+
+            this.healthReporter = healthReporter;
+            dtOutputConfiguration = new DynatraceOutputConfiguration();
+            try
+            {
+                configuration.Bind(dtOutputConfiguration);
+            }
+            catch
+            {
+                healthReporter.ReportProblem($"Invalid {nameof(DynatraceOutputConfiguration)} configuration encountered: '{configuration.ToString()}'",
+                    EventFlowContextIdentifiers.Configuration);
+                throw;
+            }
+
+            Initialize(dtOutputConfiguration);
+        }
+
+        public DynatraceOutput(DynatraceOutputConfiguration outputConfiguration, IHealthReporter healthReporter)
+        {
+            Requires.NotNull(outputConfiguration, nameof(outputConfiguration));
+            Requires.NotNull(healthReporter, nameof(healthReporter));
+
+            this.healthReporter = healthReporter;
+
+            Initialize(outputConfiguration);
+        }
+
+        public async Task SendEventsAsync(IReadOnlyCollection<EventData> events, long transmissionSequenceNumber, CancellationToken cancellationToken)
+        {
+            if (this.restClient == null || events == null || events.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+
+                MonitoredEntityMetrics m = new MonitoredEntityMetrics()
+                {
+                    type = dtOutputConfiguration.MonitoredEntity.type
+                };
+
+                bool tracked = false;
+
+                foreach (var e in events)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    if (dtOutputConfiguration.MonitoredEntity.TimeSeries != null)
+                    {
+                        IReadOnlyCollection<EventMetadata> metricMetadata = null;
+                        e.TryGetMetadata(MetricData.MetricMetadataKind, out metricMetadata);
+
+                        tracked |= TrackMetric(m, e, metricMetadata);
+                    }
+
+                    IReadOnlyCollection<EventMetadata> dtMetadata = null;
+                    e.TryGetMetadata(DynatraceEventData.MetadataKind, out dtMetadata);
+
+                    tracked |= TrackEvent(e, dtMetadata);
+                }
+
+                try
+                {
+                    if (m.series.Count > 0)
+                    {
+                        await SendMetric(dtOutputConfiguration.MonitoredEntity.entityAlias, m);
+                    }
+
+                    if (tracked)
+                        this.healthReporter.ReportWarning("Event not tracked");
+                    else
+                        this.healthReporter.ReportHealthy();
+                }
+                catch (Exception ex)
+                {
+                    this.healthReporter.ReportProblem("Diagnostics data upload has failed." + Environment.NewLine + ex.ToString());
+                    throw;
+                }
+
+            }
+            catch (Exception e)
+            {
+                this.healthReporter.ReportProblem("Diagnostics data upload has failed." + Environment.NewLine + e.ToString());
+                throw;
+            }
+
+            return;
+        }
+
+        private void Initialize(DynatraceOutputConfiguration dtOutputConfiguration)
+        {
+            Debug.Assert(dtOutputConfiguration != null);
+            Debug.Assert(this.healthReporter != null);
+
+
+            if (string.IsNullOrWhiteSpace(dtOutputConfiguration.ServiceBaseAddress))
+            {
+                this.healthReporter.ReportProblem($"{nameof(DynatraceOutput)}: 'ServiceBaseAddress' configuration parameter is not set");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(dtOutputConfiguration.ServiceAPIEndpoint))
+            {
+                this.healthReporter.ReportProblem($"{nameof(DynatraceOutput)}: 'ServiceAPIEndpoint' configuration parameter is not set");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(dtOutputConfiguration.APIToken))
+            {
+                this.healthReporter.ReportProblem($"{nameof(DynatraceOutput)}: 'APIToken' configuration parameter is not set");
+                return;
+            }
+
+            if (dtOutputConfiguration.MonitoredEntity == null)
+            {
+                this.healthReporter.ReportProblem($"{nameof(DynatraceOutput)}: 'MonitoredEntity' configuration is not set");
+                return;
+            }
+
+
+
+            restClient = new HttpClient();
+            restClient.BaseAddress = new Uri(dtOutputConfiguration.ServiceBaseAddress, UriKind.Absolute);
+            restClient.DefaultRequestHeaders.Add("Authorization", "Api-Token " + dtOutputConfiguration.APIToken);
+
+            InitializeCustomDevice(dtOutputConfiguration);
+
+            InitializeMetrics(dtOutputConfiguration);
+
+
+        }
+
+        private void InitializeMetrics(DynatraceOutputConfiguration cfg)
+        {
+            if (cfg.MonitoredEntity.TimeSeries != null)
+            {
+                InitializeMetric(cfg.MonitoredEntity.TimeSeries.timeseriesId, cfg.MonitoredEntity.TimeSeries as TimeseriesRegistrationMessage);
+            }
+        }
+
+        private async void InitializeCustomDevice(DynatraceOutputConfiguration cfg)
+        {
+            bool useIPMeta = dtOutputConfiguration.MonitoredEntity.ipAddresses != null && dtOutputConfiguration.MonitoredEntity.ipAddresses.Contains("azure-metadata");
+            bool useInstanceMeta = dtOutputConfiguration.MonitoredEntity.entityAlias == "azure-metadata";
+            if (useIPMeta || useInstanceMeta)
+            {
+                HttpClient client;
+                using (client = new HttpClient())
+                {
+                    client.DefaultRequestHeaders.Add("Metadata", "true");
+                    var response = client.GetAsync("http://169.254.169.254/metadata/instance?api-version=2017-12-01");
+
+                    try
+                    {
+                        response.Result.EnsureSuccessStatusCode();
+
+                        JObject meta = JObject.Parse(await response.Result.Content.ReadAsStringAsync());
+
+                        if (useInstanceMeta)
+                        {
+                            dtOutputConfiguration.MonitoredEntity.entityAlias = (string)meta["compute"]["name"];
+
+                            if (dtOutputConfiguration.MonitoredEntity.properties == null)
+                                dtOutputConfiguration.MonitoredEntity.properties = new Dictionary<string, string>();
+                            dtOutputConfiguration.MonitoredEntity.properties.Add("location", (string)meta["compute"]["location"]);
+                            dtOutputConfiguration.MonitoredEntity.properties.Add("osType", (string)meta["compute"]["osType"]);
+                            dtOutputConfiguration.MonitoredEntity.properties.Add("resourceGroupName", (string)meta["compute"]["resourceGroupName"]);
+                            dtOutputConfiguration.MonitoredEntity.properties.Add("subscriptionId", (string)meta["compute"]["subscriptionId"]);
+                            dtOutputConfiguration.MonitoredEntity.properties.Add("vmId", (string)meta["compute"]["vmId"]);
+                            if (!string.IsNullOrEmpty((string)meta["compute"]["vmScaleSetName"]))
+                                dtOutputConfiguration.MonitoredEntity.properties.Add("vmScaleSetName", (string)meta["compute"]["vmScaleSetName"]);
+                            if (!String.IsNullOrEmpty((string)meta["compute"]["zone"]))
+                                dtOutputConfiguration.MonitoredEntity.properties.Add("zone", (string)meta["compute"]["zone"]);
+                        }
+                        if (useIPMeta)
+                        {
+                            List<string> ip = new List<string>();
+                            ip.Add((string)meta["network"]["interface"][0]["ipv4"]["ipAddress"][0]["privateIpAddress"]);
+                            if (!String.IsNullOrEmpty((string)meta["network"]["interface"][0]["ipv4"]["ipAddress"][0]["publicIpAddress"]))
+                                ip.Add((string)meta["network"]["interface"][0]["ipv4"]["ipAddress"][0]["publicIpAddress"]);
+
+                            dtOutputConfiguration.MonitoredEntity.ipAddresses = ip.ToArray();
+                        }
+
+                    }
+                    catch (Exception ex)
+                    {
+                        this.healthReporter.ReportProblem("Couldn't resolve azure-metadata: " + ex.Message, EventFlowContextIdentifiers.Output);
+                        throw;
+                    }
+
+                }
+            }
+            
+            if (!await ResolveHostEnity(cfg.MonitoredEntity.resolveFromTag, cfg.MonitoredEntity.entityAlias, dtOutputConfiguration.MonitoredEntity))
+            {
+                entityID = (await CreateCustomDevice(cfg.MonitoredEntity.entityAlias, dtOutputConfiguration.MonitoredEntity)).entityId;
+            }
+        }
+
+        private async void InitializeMetric(string metricID, TimeseriesRegistrationMessage metric)
+        {
+
+            var httpContent = new StringContent(JsonConvert.SerializeObject(metric), Encoding.UTF8, "application/json");
+
+            var url = TimeSeriesEndoint + "custom:" + metricID;
+
+            try
+            {
+                var httpResponse = await restClient.PutAsync(url, httpContent);
+                httpResponse.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                this.healthReporter.ReportProblem("DynatraceOutput:Couldn't create timeseries: " + metricID + " ... " + ex.Message, EventFlowContextIdentifiers.Output);
+                throw;
+            }
+        }
+
+        private async Task<bool> SendMetric(string entityAlias, MonitoredEntityMetrics m)
+        {
+            if (StartWaitMetrics.HasValue && DateTime.Now.Subtract(StartWaitMetrics.Value).TotalSeconds < 15)
+            {
+                this.healthReporter.ReportWarning("Skip sending metrics", EventFlowContextIdentifiers.Output);
+                return false;
+            }
+            else
+                StartWaitMetrics = null;
+
+            var httpContent = new StringContent(JsonConvert.SerializeObject(m), Encoding.UTF8, "application/json");
+
+            var url = MetricEndoint + "custom/" + entityAlias;
+            try
+            {
+                var httpResponse = await restClient.PostAsync(url, httpContent);
+                httpResponse.EnsureSuccessStatusCode();
+
+                this.healthReporter.ReportHealthy();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                this.healthReporter.ReportProblem("DynatraceOutput:SendMetric: " + ex.ToString(), EventFlowContextIdentifiers.Output);
+                StartWaitMetrics = DateTime.Now;
+                return false;
+
+            }
+        }
+
+        private async Task<CustomDeviceResponse> CreateCustomDevice(string entityAlias, MonitoredEntity m)
+        {
+            var httpContent = new StringContent(JsonConvert.SerializeObject(m), Encoding.UTF8, "application/json");
+
+            var url = MetricEndoint + "custom/" + entityAlias;
+            try
+            {
+                var httpResponse = await restClient.PostAsync(url, httpContent);
+                httpResponse.EnsureSuccessStatusCode();
+
+                var customDevice = JsonConvert.DeserializeObject<CustomDeviceResponse>(await httpResponse.Content.ReadAsStringAsync());
+
+                this.healthReporter.ReportHealthy();
+
+                return customDevice;
+            }
+            catch (Exception ex)
+            {
+                this.healthReporter.ReportProblem("DynatraceOutput:CreateCustomDevice: " + ex.ToString(), EventFlowContextIdentifiers.Output);
+                return null;
+            }
+
+        }
+
+
+        private bool TrackMetric(MonitoredEntityMetrics m, EventData e, IReadOnlyCollection<EventMetadata> metadata)
+        {
+            bool tracked = false;
+
+            var ts = new EntityTimeseriesData()
+            {
+                timeseriesId = "custom:" + dtOutputConfiguration.MonitoredEntity.TimeSeries.timeseriesId,
+                dimensions = new Dictionary<string, string>()
+            };
+
+            if (metadata == null)
+            {
+                object eventName = null;
+
+                e.Payload.TryGetValue("EventName", out eventName);
+
+                object eventID = null;
+                if (!e.Payload.TryGetValue("ID", out eventID))
+                    eventID = 0;
+
+                ts.dimensions.Add("channel", eventName as string ?? string.Empty);
+                ts.dimensions.Add("event", eventID.ToString());
+
+                ts.dataPoints = new object[][] { new object[]
+                        {(long)(e.Timestamp.ToUniversalTime() - new DateTime(1970, 1, 1,0,0,0,DateTimeKind.Utc)).TotalMilliseconds,
+                         1 }};
+                if (m.series == null)
+                    m.series = new List<EntityTimeseriesData>();
+                m.series.Add(ts);
+            }
+            else
+            {
+                object eventName = null;
+                foreach (EventMetadata metricMetadata in metadata)
+                {
+                    var result = MetricData.TryGetData(e, metricMetadata, out MetricData metricData);
+                    if (result.Status != DataRetrievalStatus.Success)
+                    {
+                        this.healthReporter.ReportWarning("DynatraceOutput: " + result.Message, EventFlowContextIdentifiers.Output);
+                        continue;
+                    }
+
+                    ts.dimensions.Add("channel", eventName as string ?? string.Empty);
+                    ts.dimensions.Add("event", metricData.MetricName);
+                    ts.dataPoints = new object[][] { new object[] { (long)(e.Timestamp.ToUniversalTime() - new DateTime(1970, 1, 1,0,0,0,DateTimeKind.Utc)).TotalMilliseconds,
+                                                                    metricData.Value }};
+                    if (m.series == null)
+                        m.series = new List<EntityTimeseriesData>();
+                    m.series.Add(ts);
+
+                }
+
+            }
+
+            tracked = true;
+
+            return tracked;
+        }
+
+    
+        private async Task<bool> ResolveHostEnity(string resolveFromTag, string matchingEntityAlias, MonitoredEntity matchingEntity)
+        {
+    
+            try
+            {
+                if (!String.IsNullOrEmpty(resolveFromTag))
+                {
+                    var httpResponse = await restClient.GetAsync(HostEntityEndoint + "?tag=" + resolveFromTag);
+                    httpResponse.EnsureSuccessStatusCode();
+
+                    var resp = await httpResponse.Content.ReadAsStringAsync();
+                    var hosts = JArray.Parse(resp);
+
+                    for (int i = 0; i < hosts.Count; i++)
+                    {
+                        if (((string)hosts[i]["azureVmName"]) == matchingEntityAlias)
+                        {
+                            entityID = (string)hosts[i]["entityId"];
+                            return true;
+                        }
+                        else
+                        {
+                            if (hosts[i]["ipAddresses"] != null)
+                            {
+                                for (int j = 0; j < hosts[i]["ipAddresses"].Count(); j++)
+                                {
+                                    if (matchingEntity.ipAddresses.Contains((string)hosts[i]["ipAddresses"][j]))
+                                    {
+                                        entityID = (string)hosts[i]["entityId"]; ;
+                                        return true;
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                }
+                
+                return false;
+            }
+            catch (Exception e)
+            {
+                this.healthReporter.ReportWarning("DynatraceOutput - Couldn't resolve host-entity: " + e.Message, EventFlowContextIdentifiers.Output);
+                return false;
+            }
+
+            
+
+        }
+        private bool TrackEvent(EventData e, IReadOnlyCollection<EventMetadata> metadata)
+        {
+            bool tracked = false;
+
+            var msg = new EventPushMessage()
+            {
+                attachRules = new PushEventAttachRules()
+                {
+                    entityIds = new string[] { entityID }
+                },
+                source = "eventflow",
+                start = (long)(e.Timestamp.ToUniversalTime() - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds,
+                eventType = CustomEventTypes.ANNOTATION,
+            };
+           
+            object eventName = null;
+            if (!e.Payload.TryGetValue("EventName", out eventName))
+                eventName = "";
+
+            object eventID = null;
+            if (!e.Payload.TryGetValue("ID", out eventID))
+                eventID = "n/a";
+
+            object eventMsg = null;
+            if (!e.Payload.TryGetValue("Message", out eventMsg))
+                eventMsg = "n/a";
+
+            msg.annotationType = eventName.ToString() + " - " + eventID.ToString();
+            msg.annotationDescription = eventMsg.ToString();
+        
+            if (metadata != null)
+            {
+                foreach (EventMetadata eventMetadata in metadata)
+                {
+                    var result = DynatraceEventData.TryGetData(e, eventMetadata, out DynatraceEventData eventData);
+                    if (result.Status != DataRetrievalStatus.Success)
+                    {
+                        this.healthReporter.ReportWarning("DynatraceOutput: " + result.Message, EventFlowContextIdentifiers.Output);
+                        continue;
+                    }
+
+                    if (eventData.HasTargetEntity)
+                    {
+                        msg.attachRules = new PushEventAttachRules() {
+                            tagRule = new TagMatchRule[] {
+                                 new TagMatchRule() {
+                                    meTypes = new string[] {
+                                        eventData.TagMatchEntityType
+                                    },
+                                    tags = new TagInfo[] {
+                                        new TagInfo() {
+                                            key = eventData.TagMatchKey
+                                        }
+                                    }
+                                 }
+                             }
+                        };
+
+                        if (!String.IsNullOrEmpty(eventData.TagMatchContext))
+                            msg.attachRules.tagRule[0].tags[0].context = eventData.TagMatchContext;
+                    }
+
+                    if (!String.IsNullOrEmpty(eventData.Source))
+                        msg.source = eventData.Source;
+                    if (!String.IsNullOrEmpty(eventData.EventType))
+                        msg.eventType = eventData.EventType;
+
+                    if (!String.IsNullOrEmpty(eventData.AnnotationType))
+                        msg.annotationType = eventData.AnnotationType;
+                    if (!String.IsNullOrEmpty(eventData.AnnotationDescription))
+                        msg.annotationDescription = eventData.AnnotationDescription;
+
+                    if (!String.IsNullOrEmpty(eventData.Description))
+                        msg.description = eventData.Description;
+
+                    if (!String.IsNullOrEmpty(eventData.DeploymentName))
+                        msg.deploymentName = eventData.DeploymentName;
+                    if (!String.IsNullOrEmpty(eventData.DeploymentVersion))
+                        msg.deploymentVersion = eventData.DeploymentVersion;
+                    if (!String.IsNullOrEmpty(eventData.Configuration))
+                        msg.configuration = eventData.Configuration;
+
+                }
+
+            }
+         
+            SendEvent(msg);
+            tracked = true;
+
+            return tracked;
+        }
+
+        private async void SendEvent(EventPushMessage m)
+        {
+            if (StartWaitEvents.HasValue && DateTime.Now.Subtract(StartWaitEvents.Value).TotalSeconds < 15)
+            {
+                this.healthReporter.ReportWarning("Skip sending events", EventFlowContextIdentifiers.Output);
+                return;
+            }
+            else
+                StartWaitEvents = null;
+
+            try
+            {
+                var httpContent = new StringContent(JsonConvert.SerializeObject(m), Encoding.UTF8, "application/json");
+                var httpResponse = await restClient.PostAsync(EventEndoint, httpContent);
+
+                if (httpResponse.IsSuccessStatusCode)
+                {
+                    this.healthReporter.ReportHealthy();
+                }
+                else
+                {
+                    var result = httpResponse.Content.ReadAsStringAsync().Result;
+                    this.healthReporter.ReportWarning("DynatraceOutput:SendEvent failed: " + result, EventFlowContextIdentifiers.Output);
+                }
+
+                httpResponse.EnsureSuccessStatusCode();
+                
+            }
+            catch (Exception ex)
+            {
+                this.healthReporter.ReportProblem("DynatraceOutput:SendEvent: " + ex.ToString(), EventFlowContextIdentifiers.Output);
+                StartWaitEvents = DateTime.Now;
+            }
+        }
+
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/DynatraceOutputFactory.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/DynatraceOutputFactory.cs
@@ -1,0 +1,21 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.Extensions.Configuration;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs
+{
+    public class DynatraceOutputFactory : IPipelineItemFactory<DynatraceOutput>
+    {
+        public DynatraceOutput CreateItem(IConfiguration configuration, IHealthReporter healthReporter)
+        {
+            Requires.NotNull(configuration, nameof(configuration));
+            Requires.NotNull(healthReporter, nameof(healthReporter));
+
+            return new DynatraceOutput(configuration, healthReporter);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Metadata/DynatraceEventData.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Metadata/DynatraceEventData.cs
@@ -1,0 +1,138 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow.Metadata
+{
+    public class DynatraceEventData
+    {
+        public static readonly string MetadataKind = "dynatrace-event";
+
+        public string TagMatchEntityType { get; private set; }
+        public string TagMatchContext { get; private set; }
+        public string TagMatchKey { get; private set; }
+        public string TagMatchValue { get; private set; }
+        
+        public bool HasTargetEntity
+        {
+            get
+            {
+                return (!String.IsNullOrEmpty(TagMatchEntityType) && !String.IsNullOrEmpty(TagMatchKey));
+            }
+        }
+
+        public string Source { get; private set; }
+        public string EventType { get; private set; }
+        public string AnnotationType { get; private set; }
+        public string AnnotationDescription { get; private set; }
+        public string Description { get; private set; }
+        public string DeploymentName { get; private set; }
+        public string DeploymentVersion { get; private set; }
+        public string Configuration { get; private set; }
+
+        // Ensure that DynatraceEventData can only be created using TryGetData() method
+        private DynatraceEventData() { }
+
+        public static DataRetrievalResult TryGetData(
+            EventData eventData,
+            EventMetadata eventMetadata,
+            out DynatraceEventData meta)
+        {
+            Requires.NotNull(eventData, nameof(eventData));
+            Requires.NotNull(eventMetadata, nameof(eventMetadata));
+
+            meta = null;
+
+            if (!MetadataKind.Equals(eventMetadata.MetadataType, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return DataRetrievalResult.InvalidMetadataType(eventMetadata.MetadataType, MetadataKind);
+            }
+
+            meta = new DynatraceEventData();
+            meta.Source = eventMetadata["source"];
+            meta.EventType = eventMetadata["eventType"];
+            meta.AnnotationType = eventMetadata["annotationType"];
+            meta.AnnotationDescription = eventMetadata["annotationDescription"];
+            meta.Description = eventMetadata["description"];
+            meta.DeploymentName = eventMetadata["deploymentName"];
+            meta.DeploymentVersion = eventMetadata["deploymentVersion"];
+            meta.Configuration = eventMetadata["configuration"];
+
+            meta.TagMatchEntityType = eventMetadata["tagMatchEntityType"];
+            meta.TagMatchContext = eventMetadata["tagMatchContext"];
+            meta.TagMatchKey = eventMetadata["tagMatchKey"];
+            meta.TagMatchValue = eventMetadata["tagMatchValue"];
+
+            string val = "";
+            string property = eventMetadata["annotationTypeProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.AnnotationType = val;
+            }
+            property = eventMetadata["annotationDescriptionProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.AnnotationDescription = val;
+            }
+            property = eventMetadata["descriptionProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.Description = val;
+            }
+
+            property = eventMetadata["deploymentNameProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.DeploymentName = val;
+            }
+            property = eventMetadata["deploymentVersionProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.DeploymentVersion = val;
+            }
+            property = eventMetadata["configuratonProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.DeploymentVersion = val;
+            }
+
+            property = eventMetadata["tagMatchEntityTypeProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.TagMatchEntityType = val;
+            }
+
+            property = eventMetadata["tagMatchContextProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.TagMatchContext = val;
+            }
+            property = eventMetadata["tagMatchKeyProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.TagMatchKey = val;
+            }
+            property = eventMetadata["tagMatchValueProperty"];
+            if (!string.IsNullOrEmpty(property))
+            {
+                if (eventData.GetValueFromPayload<string>(property, (v) => val = v))
+                    meta.TagMatchValue = val;
+            }
+            return DataRetrievalResult.Success;
+        }        
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Provides an output implementation that sends diagnostics data to Dynatrace Cluster.</Description>
+    <Copyright>Dynatrace LLC</Copyright>
+    <Authors>Dynatrace LLC</Authors>
+    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace</AssemblyName>
+    <VersionPrefix>1.4.0</VersionPrefix>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace</PackageId>
+    <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Dynatrace</PackageTags>
+    <PackageProjectUrl>https://github.com/Azure/diagnostics-eventflow</PackageProjectUrl>
+    <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Diagnostics.EventFlow.Core\Microsoft.Diagnostics.EventFlow.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/CustomDeviceResponse.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/CustomDeviceResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class CustomDeviceResponse
+    {
+        public string entityId { get; set; }
+        public string groupId { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/CustomEventTypes.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/CustomEventTypes.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class CustomEventTypes
+    {
+        public static readonly string ANNOTATION = "CUSTOM_ANNOTATION";
+        public static readonly string CONFIGURATION = "CUSTOM_CONFIGURATION";
+        public static readonly string DEPLOYMENT = "CUSTOM_DEPLOYMENT";
+        public static readonly string INFO = "CUSTOM_INFO";
+
+        public static readonly string AVAILABILITY = "AVAILABILITY_EVENT";
+        public static readonly string ERROR = "ERROR_EVENT";
+        public static readonly string PERFORMANCE = "PERFORMANCE_EVENT";
+        public static readonly string RESOURCE = "RESOURCE_CONTENTION";
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/EntityTimeseriesData.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/EntityTimeseriesData.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class EntityTimeseriesData
+    {
+        public string timeseriesId { get; set; }
+        public Dictionary<string, string> dimensions { get; set; }
+        public object[][] dataPoints { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/EventPushMessage.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/EventPushMessage.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class EventPushMessage
+    {
+        public string eventType { get; set;}
+        public long start {get; set;}
+        public PushEventAttachRules attachRules { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string source { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string annotationType { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string annotationDescription { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string description { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string deploymentName { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string deploymentVersion { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string configuration { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/MonitoredEntity.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/MonitoredEntity.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+   
+    public class MonitoredEntity
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string displayName { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string[] ipAddresses { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string[] listenPorts { get; set; }
+        public string type { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string favicon { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string configUrl { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string[] tags  { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, string> properties { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/MonitoredEntityMetrics.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/MonitoredEntityMetrics.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+   
+    public class MonitoredEntityMetrics
+    {
+        public string type { get; set; }
+        public List<EntityTimeseriesData> series { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/PushEventAttachRules .cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/PushEventAttachRules .cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class PushEventAttachRules
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string[] entityIds { get; set;}
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public TagMatchRule[] tagRule { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/TagInfo.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/TagInfo.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class TagInfo
+    {
+        public string context { get; set; }
+        public string key { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string value { get; set; }
+
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/TagMatchRule.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/TagMatchRule.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class TagMatchRule
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string[] meTypes { get; set; }
+        public TagInfo[] tags { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/TimeseriesRegistrationMessage.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Model/TimeseriesRegistrationMessage.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace.Model
+{
+    public class TimeseriesRegistrationMessage
+    {
+        public string displayName { get; set; }
+        public string unit { get; set; }    
+        public string[] dimensions { get; set; }
+        public string[] types { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.Diagnostics.EventFlow.Outputs.Dynatrace")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("49a23dff-ce13-4413-a024-65247b30d09c")]


### PR DESCRIPTION
I've added a Dynatrace output utilizing the Dynatrace REST API. 

A lot of background info can be found in a tutorial specifically made for Service Fabric in it's originating repo:  https://github.com/Dynatrace/diagnostics-eventflow/tree/output-dynatrace-examples/examples/ServiceFabric.
