### PR TITLE
Log4Net input should not emit traces to console

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Log4net/Log4netInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Log4net/Log4netInput.cs
@@ -74,10 +74,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             {
                 eventFlowRepo = (Hierarchy)LogManager.CreateRepository("EventFlowRepo");
                 _log4NetInputConfiguration.Log4netLevel = eventFlowRepo.LevelMap[_log4NetInputConfiguration.LogLevel];
-
-                eventFlowRepo.Root.AddAppender(this);
-                eventFlowRepo.Configured = true;
-                BasicConfigurator.Configure(eventFlowRepo);
+                BasicConfigurator.Configure(eventFlowRepo, this);
             }
             catch (LogException)
             {

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Log4net/Microsoft.Diagnostics.EventFlow.Inputs.Log4net.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Log4net/Microsoft.Diagnostics.EventFlow.Inputs.Log4net.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Inputs.Log4net infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Log4net</AssemblyName>


### PR DESCRIPTION
Just noticed that Log4Net input will allow traces to be sent to Console.Out. This should not happen.