### PR TITLE
Move high precision timestamps from EventSource input to Core

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DateTimePrecise.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DateTimePrecise.cs
@@ -1,0 +1,39 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+#if NET451 || NET471
+using System.Runtime.InteropServices;
+#endif
+
+namespace Microsoft.Diagnostics.EventFlow
+{
+    public static class DateTimePrecise
+    {
+#if NET451 || NET471
+        [DllImport("Kernel32.dll", CallingConvention = CallingConvention.Winapi)]
+        private static extern void GetSystemTimePreciseAsFileTime(out long filetime);
+
+        private static readonly bool UseSystemTimePrecise =
+            Environment.OSVersion.Platform == PlatformID.Win32NT
+         && (Environment.OSVersion.Version.Major >= 10 || (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor >= 2));
+#endif
+
+        public static DateTime UtcNow
+        {
+            get
+            {
+#if NET451 || NET471
+                if (UseSystemTimePrecise)
+                {
+                    GetSystemTimePreciseAsFileTime(out var filetime);
+                    return DateTime.FromFileTimeUtc(filetime);
+                }
+#endif
+                return DateTime.UtcNow;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.5.5</VersionPrefix>
+    <VersionPrefix>1.5.6</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451;net471</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource/EventObserver.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource/EventObserver.cs
@@ -32,9 +32,10 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource
 
         public void OnNext(KeyValuePair<string, object> pair)
         {
-            var eventData = new EventData { ProviderName = _providerName, Timestamp = DateTimeOffset.UtcNow };
-            eventData.Payload["EventName"] = pair.Key;
-            eventData.Payload["Value"] = pair.Value;
+            var eventData = new EventData { ProviderName = _providerName, Timestamp = DateTimePrecise.UtcNow };
+            var payload = eventData.Payload;
+            payload["EventName"] = pair.Key;
+            payload["Value"] = pair.Value;
 
             var activity = Activity.Current;
             if (activity != null)
@@ -42,28 +43,19 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource
                 var id = activity.Id;
                 if (id != null)
                 {
-                    eventData.Payload["ActivityId"] = id;
+                    payload["ActivityId"] = id;
                 }
 
                 var parentId = activity.ParentId;
                 if (parentId != null)
                 {
-                    eventData.Payload["ActivityParentId"] = parentId;
+                    payload["ActivityParentId"] = parentId;
                 }
 
                 var duration = activity.Duration;
                 if (duration != TimeSpan.Zero)
                 {
-                    eventData.Payload["Duration"] = duration;
-                }
-
-                var tags = activity.Tags;
-                if (tags != null)
-                {
-                    foreach (var tag in tags)
-                    {
-                        eventData.AddPayloadProperty(tag.Key, tag.Value, _healthReporter, nameof(DiagnosticSourceInput));
-                    }
+                    payload["Duration"] = duration;
                 }
 
                 var baggage = activity.Baggage;
@@ -72,6 +64,15 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource
                     foreach (var bag in baggage)
                     {
                         eventData.AddPayloadProperty(bag.Key, bag.Value, _healthReporter, nameof(DiagnosticSourceInput));
+                    }
+                }
+
+                var tags = activity.Tags;
+                if (tags != null)
+                {
+                    foreach (var tag in tags)
+                    {
+                        eventData.AddPayloadProperty(tag.Key, tag.Value, _healthReporter, nameof(DiagnosticSourceInput));
                     }
                 }
             }

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource</AssemblyName>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;DiagnosticSource</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Tracing.EventSource infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.4.3</VersionPrefix>
+    <VersionPrefix>1.4.4</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.EventSource</AssemblyName>

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DateTimePreciseTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DateTimePreciseTests.cs
@@ -1,0 +1,57 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+#if !NETCOREAPP1_0
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.EventFlow.Core.Tests
+{
+    public class DateTimePreciseTests
+    {
+        private static double GetAverageResolution()
+        {
+            const int count = 1000;
+            var precisions = new List<double>(count);
+            for (var i = 0; i < count; ++i)
+            {
+                precisions.Add(GetResolution().TotalMilliseconds);
+            }
+            return precisions.Average();
+        }
+
+        private static TimeSpan GetResolution()
+        {
+            var t1 = DateTimePrecise.UtcNow;
+            DateTime t2;
+            while ((t2 = DateTimePrecise.UtcNow) == t1)
+            {
+                // Spin until the time changes
+            }
+            return t2 - t1;
+        }
+
+        [Fact]
+        public void DateTimeIsHighPrecision()
+        {
+            if (!(Environment.OSVersion.Platform == PlatformID.Win32NT
+               && (Environment.OSVersion.Version.Major >= 10 || (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor >= 2))))
+            {
+                // We only use explicit high-precision timestamping on Windows, relying on .NET implementation defaults for other platforms
+                return;
+            }
+
+            // We should be able to use 0.001 here. It works from a command line application but not the test runner.
+            const double expectedMs = 1.1;
+
+            var actualMs = GetAverageResolution();
+
+            Assert.True(actualMs <= expectedMs, $"Expected a higher resolution than {expectedMs}ms but got {actualMs:0.000}ms");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
- Move high precision timestamps from EventSource input to Core
- Use high precision timestamps from DiagnosticSource input
- Give DiagnosticSource baggage items precedence over tags in the event of a conflict, to improve correlation across activities