### PR TITLE
Update OmsOutput.cs

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Oms</AssemblyName>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.4.1</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.Oms</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Microsoft Operations Management</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Oms</AssemblyName>
-    <VersionPrefix>1.4.1</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.Oms</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Microsoft Operations Management</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
@@ -115,10 +115,9 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                 string jsonData = JsonConvert.SerializeObject(events);
 
                 string dateString = DateTime.UtcNow.ToString("r");
-
-                string signature = BuildSignature(jsonData, dateString);
-
                 HttpContent content = new StringContent(jsonData, Encoding.UTF8, JsonContentId);
+                string signature = this.BuildSignature(content.Headers.ContentLength, dateString);
+				
                 content.Headers.ContentType = new MediaTypeHeaderValue(JsonContentId);
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, OmsDataUploadUrl);
                 request.Headers.Add("Authorization", signature);
@@ -154,11 +153,10 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             }
         }
 
-        private string BuildSignature(string message, string dateString)
+        private string BuildSignature(long? contentLength, string dateString)
         {
             string dateHeader = $"{MsDateHeaderName}:{dateString}";
-            byte[] messageInBytes = Encoding.UTF8.GetBytes(message);
-            string signatureInput = $"POST\n{messageInBytes.Length}\n{JsonContentId}\n{dateHeader}\n{OmsDataUploadResource}";
+            string signatureInput = $"POST\n{contentLength}\n{JsonContentId}\n{dateHeader}\n{OmsDataUploadResource}";
             byte[] signatureInputBytes = Encoding.ASCII.GetBytes(signatureInput);
             byte[] hash;
             lock(this.connectionData.Hasher)

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/OmsOutput.cs
@@ -157,7 +157,8 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
         private string BuildSignature(string message, string dateString)
         {
             string dateHeader = $"{MsDateHeaderName}:{dateString}";
-            string signatureInput = $"POST\n{message.Length}\n{JsonContentId}\n{dateHeader}\n{OmsDataUploadResource}";
+            byte[] messageInBytes = Encoding.UTF8.GetBytes(message);
+            string signatureInput = $"POST\n{messageInBytes.Length}\n{JsonContentId}\n{dateHeader}\n{OmsDataUploadResource}";
             byte[] signatureInputBytes = Encoding.ASCII.GetBytes(signatureInput);
             byte[] hash;
             lock(this.connectionData.Hasher)


### PR DESCRIPTION
fix data-specific authorization failure: content-length must be in byte size