### PR TITLE
Add ingest node default pipeline support to Elasticsearch output

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,7 +806,8 @@ This output writes data to the [Elasticsearch](https://www.elastic.co/products/e
     "eventDocumentTypeName": "diagData",
     "numberOfShards": 1,
     "numberOfReplicas": 1,
-    "refreshInterval": "15s"
+    "refreshInterval": "15s",
+    "defaultPipeline": "my-pipeline"
 }
 ```
 | Field | Values/Types | Required | Description |
@@ -821,6 +822,7 @@ This output writes data to the [Elasticsearch](https://www.elastic.co/products/e
 | `numberOfShards` | int | No | Specifies how many shards to create the index with. If not specified, it defaults to 1.|
 | `numberOfReplicas` | int | No | Specifies how many replicas the index is created with. If not specified, it defaults to 5.|
 | `refreshInterval` | string | No | Specifies what refresh interval the index is created with. If not specified, it defaults to 15s.|
+| `defaultPipeline` | string | No | Specifies the default ingest node pipeline the index is created with. If not specified, a default pipeline will not be used.|
 
 
 *Standard metadata support*

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchOutputConfiguration.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
         public int NumberOfShards { get; set; }
         public int NumberOfReplicas { get; set; }
         public string RefreshInterval { get; set; }
+        public string DefaultPipeline { get; set; }
 
         public ElasticSearchOutputConfiguration()
         {
@@ -52,6 +53,7 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
                 NumberOfShards = this.NumberOfShards,
                 NumberOfReplicas = this.NumberOfReplicas,
                 RefreshInterval = this.RefreshInterval,
+                DefaultPipeline = this.DefaultPipeline,
             };
 
             return other;

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
@@ -388,6 +388,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             indexSettings.Settings.NumberOfReplicas = this.connectionData.Configuration.NumberOfReplicas;
             indexSettings.Settings.NumberOfShards = this.connectionData.Configuration.NumberOfShards;
             indexSettings.Settings.Add("refresh_interval", this.connectionData.Configuration.RefreshInterval);
+            indexSettings.Settings.Add("default_pipeline", this.connectionData.Configuration.DefaultPipeline);
 
             ICreateIndexResponse createIndexResult = await esClient.CreateIndexAsync(indexName, c => c.InitializeUsing(indexSettings)).ConfigureAwait(false);
 


### PR DESCRIPTION
Adds configuration parameter to Elasticsearch output config type, allowing user to specify a default pipeline to be used when creating a new index.  This corresponds to the [`index.default_pipeline` dynamic index setting](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/index-modules.html#dynamic-index-settings).

Having this specified during index creation ensures that, if pipeline usage is desired in a given use case, that all documents indexed are done via the pipeline from the inception of that index.