### PR TITLE
Fix metric metadata for EventSourceInput

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventDataExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/EventDataExtensions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
         private static EventMetadata CreateMetricMetadata(string property)
         {
             EventMetadata eventMetadata = new EventMetadata(MetricData.MetricMetadataKind);
-            eventMetadata.Properties.Add(MetricData.MetricNamePropertyMoniker, property);
+            eventMetadata.Properties.Add(MetricData.MetricNameMoniker, property);
             eventMetadata.Properties.Add(MetricData.MetricValuePropertyMoniker, property);
 
             return eventMetadata;

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.EventSource/Microsoft.Diagnostics.EventFlow.Inputs.EventSource.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Tracing.EventSource infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.4.5</VersionPrefix>
+    <VersionPrefix>1.4.6</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.EventSource</AssemblyName>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EventSourceInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EventSourceInputTests.cs
@@ -283,6 +283,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
 
                 var expectedMetrics = new List<string>(new string[]{"Mean", "StandardDeviation", "Count", "Min", "Max", "IntervalSec"});
                 Assert.All(metadata, em => expectedMetrics.Contains(em.Properties[MetricData.MetricValuePropertyMoniker], StringComparer.InvariantCulture));
+                Assert.All(metadata, em => expectedMetrics.Contains(em.Properties[MetricData.MetricNameMoniker], StringComparer.InvariantCulture));
             }
         }
 


### PR DESCRIPTION
Addresses [issue 323](https://github.com/Azure/diagnostics-eventflow/issues/323)