### PR TITLE
Improve batch timer handling in DiagnosticPipeline

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DiagnosticPipeline.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DiagnosticPipeline.cs
@@ -20,10 +20,11 @@ namespace Microsoft.Diagnostics.EventFlow
     public class DiagnosticPipeline : IDisposable
     {
         private List<IDisposable> inputSubscriptions;
-        private IDisposable batcherTimer;
+        private Timer batcherTimer;
         private List<Task> outputCompletionTasks;
         private bool disposed;
         private bool disposeDependencies;
+        private object disposalLock;
         private CancellationTokenSource cancellationTokenSource;
         private IDataflowBlock pipelineHead;
         private DiagnosticPipelineConfiguration pipelineConfiguration;
@@ -43,6 +44,7 @@ namespace Microsoft.Diagnostics.EventFlow
             Requires.NotNull(sinks, nameof(sinks));
             Requires.Argument(sinks.Count > 0, nameof(sinks), "There must be at least one sink");
 
+            this.disposalLock = new object();
             this.pipelineConfiguration = pipelineConfiguration ?? new DiagnosticPipelineConfiguration();
             taskScheduler = taskScheduler ?? TaskScheduler.Current;
 
@@ -84,12 +86,6 @@ namespace Microsoft.Diagnostics.EventFlow
                     }
                 );
             inputBuffer.LinkTo(batcher, propagateCompletion);
-
-            this.batcherTimer = new Timer(
-                (unused) => { try { batcher.TriggerBatch(); } catch {} },
-                state: null,
-                dueTime: TimeSpan.FromMilliseconds(this.pipelineConfiguration.MaxBatchDelayMsec),
-                period: TimeSpan.FromMilliseconds(this.pipelineConfiguration.MaxBatchDelayMsec));
 
             ISourceBlock<EventData[]> sinkSource;
             FilterAction filterTransform;
@@ -182,17 +178,41 @@ namespace Microsoft.Diagnostics.EventFlow
 
             this.disposed = false;
             this.disposeDependencies = disposeDependencies;
+
+            this.batcherTimer = new Timer(
+                (unused) => {
+                    try
+                    {
+                        lock (this.disposalLock)
+                        {
+                            if (!this.disposed)
+                            {
+                                batcher.TriggerBatch();
+
+                                this.batcherTimer.Change(dueTime: TimeSpan.FromMilliseconds(this.pipelineConfiguration.MaxBatchDelayMsec), period: Timeout.InfiniteTimeSpan);
+                            }
+                        }
+                    }
+                    catch { }
+                },
+                state: null,
+                dueTime: TimeSpan.FromMilliseconds(this.pipelineConfiguration.MaxBatchDelayMsec),
+                period: Timeout.InfiniteTimeSpan);
         }
 
         public void Dispose()
         {
-            if (this.disposed)
+            lock (this.disposalLock)
             {
-                return;
+                if (this.disposed)
+                {
+                    return;
+                }
+
+                this.disposed = true;
+                this.batcherTimer.Dispose();
             }
-
-            this.disposed = true;
-
+            
             DisposeOf(this.inputSubscriptions);
 
             pipelineHead.Complete();
@@ -200,8 +220,6 @@ namespace Microsoft.Diagnostics.EventFlow
             Task.WhenAny(Task.WhenAll(this.outputCompletionTasks.ToArray()), Task.Delay(this.pipelineConfiguration.PipelineCompletionTimeoutMsec)).GetAwaiter().GetResult();
 
             this.cancellationTokenSource.Cancel();
-
-            this.batcherTimer.Dispose();
 
             if (this.disposeDependencies)
             {

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.5.7</VersionPrefix>
+    <VersionPrefix>1.5.8</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451;net471</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>


### PR DESCRIPTION
This is an attempt to reduce the possibility of ending in a state described in issue 311 https://github.com/Azure/diagnostics-eventflow/issues/311 It is not entirely clear to me what the problem is there because I have a very hard time reproducing the issue, but the one time when it did repro with debugger attached, I saw that the batcher timer was not being fired. As far as I could tell there was nothing wrong with EventFlow pipeline.

I suspect this is an initialization timing issue that results in thread pool thred exhaustion and the timer proc not being scheduled as it should. One can get more or less to the same state when threadpool threads are manually suspended (the timer is no longer fired, and no new threads are added to the thread pool).

This change ensures that only one timer proc is ever running, so it should help, and in general is a good rule to follow.