### PR TITLE
Outputs.ElasticSearch: Added a way to describe properties mappings on index creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,15 @@ This output writes data to the [Elasticsearch](https://www.elastic.co/products/e
     "numberOfShards": 1,
     "numberOfReplicas": 1,
     "refreshInterval": "15s",
-    "defaultPipeline": "my-pipeline"
+    "defaultPipeline": "my-pipeline",
+    "mappings": {
+        "properties": {
+            "timestamp": {
+                "type": "date_nanos"
+            }
+        }
+    }
+
 }
 ```
 | Field | Values/Types | Required | Description |
@@ -820,7 +828,8 @@ This output writes data to the [Elasticsearch](https://www.elastic.co/products/e
 | `numberOfReplicas` | int | No | Specifies how many replicas the index is created with. If not specified, it defaults to 5.|
 | `refreshInterval` | string | No | Specifies what refresh interval the index is created with. If not specified, it defaults to 15s.|
 | `defaultPipeline` | string | No | Specifies the default ingest node pipeline the index is created with. If not specified, a default pipeline will not be used.|
-
+| `mappings`        | object | No | Specifies specific index properties mappings. The mappings are configured by defining the each property.
+| `mappings.properties` | object | No | Specifies the index properties. The format resembles the mappings definition when creating index with ElasticSearch with some constraints - only property name and type definition is supported.
 
 *Standard metadata support*
 

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchMappingsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchMappingsConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.EventFlow.Configuration
+{
+    public class ElasticSearchMappingsConfiguration
+    {
+        public Dictionary<string, ElasticSearchMappingsConfigurationPropertyDescriptor> Properties { get; set; }
+
+        internal ElasticSearchMappingsConfiguration DeepClone()
+        {
+            var other = new ElasticSearchMappingsConfiguration();
+            other.Properties = new Dictionary<string, ElasticSearchMappingsConfigurationPropertyDescriptor>();
+
+            foreach (var item in this.Properties)
+            {
+                other.Properties.Add(item.Key, item.Value.DeepClone());
+            }
+
+            return other;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchMappingsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchMappingsConfiguration.cs
@@ -8,12 +8,16 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
 {
     public class ElasticSearchMappingsConfiguration
     {
-        public Dictionary<string, ElasticSearchMappingsConfigurationPropertyDescriptor> Properties { get; set; }
+        public Dictionary<string, ElasticSearchMappingsConfigurationPropertyDescriptor> Properties { get; private set; }
+
+        public ElasticSearchMappingsConfiguration()
+        {
+            Properties = new Dictionary<string, ElasticSearchMappingsConfigurationPropertyDescriptor>();
+        }
 
         internal ElasticSearchMappingsConfiguration DeepClone()
         {
             var other = new ElasticSearchMappingsConfiguration();
-            other.Properties = new Dictionary<string, ElasticSearchMappingsConfigurationPropertyDescriptor>();
 
             foreach (var item in this.Properties)
             {

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchMappingsConfigurationPropertyDescriptor.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchMappingsConfigurationPropertyDescriptor.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.EventFlow.Configuration
+{
+    public class ElasticSearchMappingsConfigurationPropertyDescriptor
+    {
+        public string Type { get; set; }
+
+        internal ElasticSearchMappingsConfigurationPropertyDescriptor DeepClone()
+        {
+            var other = new ElasticSearchMappingsConfigurationPropertyDescriptor
+            {
+                Type = this.Type
+            };
+
+            return other;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchOutputConfiguration.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
         public string RefreshInterval { get; set; }
         public string DefaultPipeline { get; set; }
 
-        public ElasticSearchMappingsConfiguration Mappings { get; set; }
+        public ElasticSearchMappingsConfiguration Mappings { get; private set; }
 
         public ElasticSearchOutputConfiguration()
         {
@@ -40,6 +40,7 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
             NumberOfShards = DefaultNumberOfShards;
             NumberOfReplicas = DefaultNumberOfReplicas;
             RefreshInterval = DefaultRefreshInterval;
+            Mappings = new ElasticSearchMappingsConfiguration();
         }
 
         public ElasticSearchOutputConfiguration DeepClone()

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Configuration/ElasticSearchOutputConfiguration.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
         public string RefreshInterval { get; set; }
         public string DefaultPipeline { get; set; }
 
+        public ElasticSearchMappingsConfiguration Mappings { get; set; }
+
         public ElasticSearchOutputConfiguration()
         {
             EventDocumentTypeName = DefaultEventDocumentTypeName;
@@ -54,6 +56,7 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
                 NumberOfReplicas = this.NumberOfReplicas,
                 RefreshInterval = this.RefreshInterval,
                 DefaultPipeline = this.DefaultPipeline,
+                Mappings = this.Mappings.DeepClone()
             };
 
             return other;

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/CreateIndexRequestBuilder.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/CreateIndexRequestBuilder.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.EventFlow.Configuration;
+using Nest;
+using Validation;
+
+namespace Microsoft.Diagnostics.EventFlow.Outputs
+{
+    internal class CreateIndexRequestBuilder
+    {
+        private readonly ElasticSearchOutputConfiguration configuration;
+        private readonly IHealthReporter healthReporter;
+
+        internal CreateIndexRequestBuilder(Configuration.ElasticSearchOutputConfiguration configuration, IHealthReporter healthReporter)
+        {
+            Requires.NotNull(configuration, nameof(configuration));
+            Requires.NotNull(healthReporter, nameof(healthReporter));
+
+            this.configuration = configuration;
+            this.healthReporter = healthReporter;
+        }
+
+        static readonly Dictionary<string, Func<PropertiesDescriptor<object>, string, PropertiesDescriptor<object>>> typeToPropertiesDesctiptorFunc =
+            new Dictionary<string, Func<PropertiesDescriptor<object>, string, PropertiesDescriptor<object>>>
+            {
+                ["text"] = (pd, name) => pd.Text(a => a.Name(name)),
+                ["keyword"] = (pd, name) => pd.Keyword(p => p.Name(name)),
+                ["date"] = (pd, name) => pd.Date(p => p.Name(name)),
+                ["date_nanos"] = (pd, name) => pd.DateNanos(p => p.Name(name)),
+                ["boolean"] = (pd, name) => pd.Boolean(p => p.Name(name)),
+                ["long"] = (pd, name) => pd.Number(p => p.Name(name).Type(NumberType.Long)),
+                ["integer"] = (pd, name) => pd.Number(p => p.Name(name).Type(NumberType.Integer)),
+                ["short"] = (pd, name) => pd.Number(p => p.Name(name).Type(NumberType.Short)),
+                ["byte"] = (pd, name) => pd.Number(p => p.Name(name).Type(NumberType.Byte)),
+                ["double"] = (pd, name) => pd.Number(p => p.Name(name).Type(NumberType.Double)),
+                ["float"] = (pd, name) => pd.Number(p => p.Name(name).Type(NumberType.Float)),
+                ["half_float"] = (pd, name) => pd.Number(p => p.Name(name).Type(NumberType.HalfFloat)),
+                ["scaled_float"] = (pd, name) => pd.Number(p => p.Name(name).Type(NumberType.ScaledFloat)),
+                ["ip"] = (pd, name) => pd.Ip(p => p.Name(name)),
+                ["geo_point"] = (pd, name) => pd.GeoPoint(p => p.Name(name)),
+                ["geo_shape"] = (pd, name) => pd.GeoShape(p => p.Name(name)),
+                ["completion"] = (pd, name) => pd.Completion(p => p.Name(name))
+            };
+
+
+        private TypeMappingDescriptor<object> mappingsSelector(TypeMappingDescriptor<object> tm)
+        {
+            return tm.Properties(pd =>
+            {
+                PropertiesDescriptor<object> properties = pd;
+                foreach (var propMapping in configuration.Mappings.Properties)
+                {
+                    string propertyType = propMapping.Value.Type;
+                    string propertyName = propMapping.Key;
+
+                    if (!typeToPropertiesDesctiptorFunc.ContainsKey(propertyType))
+                    {
+                        string errorMessage = $"{nameof(ElasticSearchOutput)}: {propertyName} property mapping could not be set because configured type ({propertyType}) is not supported.";
+                        healthReporter.ReportWarning(errorMessage, EventFlowContextIdentifiers.Output);
+                    }
+                    else
+                    {
+                        properties = typeToPropertiesDesctiptorFunc[propertyType](properties, propertyName);
+                    }
+                }
+
+                return properties;
+            });
+        }
+
+        private IndexSettingsDescriptor settingsSelector(IndexSettingsDescriptor s)
+        {
+            s = s.NumberOfReplicas(configuration.NumberOfReplicas)
+                .NumberOfShards(configuration.NumberOfShards)
+                .RefreshInterval(configuration.RefreshInterval);
+
+            if (!string.IsNullOrWhiteSpace(configuration.DefaultPipeline))
+                s = s.DefaultPipeline(configuration.DefaultPipeline);
+
+            return s;
+        }
+
+        internal ICreateIndexRequest Selector(CreateIndexDescriptor c)
+        {
+            return 
+                c.Settings(settingsSelector)
+                .Map(mappingsSelector);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/CreateIndexRequestBuilder.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/CreateIndexRequestBuilder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             };
 
 
-        private TypeMappingDescriptor<object> mappingsSelector(TypeMappingDescriptor<object> tm)
+        private TypeMappingDescriptor<object> applyTypeMapping(TypeMappingDescriptor<object> tm)
         {
             return tm.Properties(pd =>
             {
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             });
         }
 
-        private IndexSettingsDescriptor settingsSelector(IndexSettingsDescriptor s)
+        private IndexSettingsDescriptor applyIndexSettings(IndexSettingsDescriptor s)
         {
             s = s.NumberOfReplicas(configuration.NumberOfReplicas)
                 .NumberOfShards(configuration.NumberOfShards)
@@ -83,11 +83,11 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             return s;
         }
 
-        internal ICreateIndexRequest Selector(CreateIndexDescriptor c)
+        internal ICreateIndexRequest BuildRequest(CreateIndexDescriptor c)
         {
             return 
-                c.Settings(settingsSelector)
-                .Map(mappingsSelector);
+                c.Settings(applyIndexSettings)
+                .Map(applyTypeMapping);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             CreateIndexRequestBuilder createIndexRequestBuilder = new CreateIndexRequestBuilder(this.connectionData.Configuration, this.healthReporter);
 
 
-            CreateIndexResponse createIndexResult = await esClient.Indices.CreateAsync(indexName, createIndexRequestBuilder.Selector).ConfigureAwait(false);
+            CreateIndexResponse createIndexResult = await esClient.Indices.CreateAsync(indexName, createIndexRequestBuilder.BuildRequest).ConfigureAwait(false);
 
             if (!createIndexResult.IsValid)
             {

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
@@ -364,19 +364,11 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             {
                 return;
             }
-            
-            // TODO: allow the consumer to fine-tune index settings
-            IndexState indexSettings = new IndexState();
-            indexSettings.Settings = new IndexSettings();
-            indexSettings.Settings.NumberOfReplicas = this.connectionData.Configuration.NumberOfReplicas;
-            indexSettings.Settings.NumberOfShards = this.connectionData.Configuration.NumberOfShards;
-            indexSettings.Settings.Add("refresh_interval", this.connectionData.Configuration.RefreshInterval);
-            if (this.connectionData.Configuration.DefaultPipeline != null)
-            {
-                indexSettings.Settings.Add("default_pipeline", this.connectionData.Configuration.DefaultPipeline);
-            }
 
-            CreateIndexResponse createIndexResult = await esClient.Indices.CreateAsync(indexName, c => c.InitializeUsing(indexSettings)).ConfigureAwait(false);
+            CreateIndexRequestBuilder createIndexRequestBuilder = new CreateIndexRequestBuilder(this.connectionData.Configuration, this.healthReporter);
+
+
+            CreateIndexResponse createIndexResult = await esClient.Indices.CreateAsync(indexName, createIndexRequestBuilder.Selector).ConfigureAwait(false);
 
             if (!createIndexResult.IsValid)
             {

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/ElasticSearchOutputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/ElasticSearchOutputTests.cs
@@ -35,6 +35,16 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                         ["numberOfReplicas"] = 20,
                         ["refreshInterval"] = "60s",
                         ["useSniffingConnectionPooling"] = "true",
+                        ["mappings"] = new Dictionary<string, object>
+                        {
+                            ["properties"]= new Dictionary<string, object>
+                            {
+                                ["timestamp"] = new Dictionary<string, object>
+                                {
+                                    ["type"] = "date_nanos"
+                                }
+                            }
+                        }
                     }
                 }
             };
@@ -61,6 +71,12 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 Assert.Equal(10, esOutputConfiguration.NumberOfShards);
                 Assert.Equal(20, esOutputConfiguration.NumberOfReplicas);
                 Assert.Equal("60s", esOutputConfiguration.RefreshInterval);
+
+                Assert.NotNull(esOutputConfiguration.Mappings);
+                Assert.NotNull(esOutputConfiguration.Mappings.Properties);
+                Assert.NotNull(esOutputConfiguration.Mappings.Properties["timestamp"]);
+
+                Assert.Equal("date_nanos", esOutputConfiguration.Mappings.Properties["timestamp"].Type);
             }
         }
 


### PR DESCRIPTION
In order to be able to describe the properties (their names and types), there should be a way to do this through the configuration.

The need for explicitly describing properties mapping comes when you want to use date_nanos type for the timestamp property. The default dynamic field mapping for dates sets the type to date and thus nanoseconds precision is lost.

To override the dynamic mapping for a specific property, one has to explicitly define the mapping of the property.

In the configuration for the elastic search output now you can describe the mapping like this:
```javascript
      "mappings": {
        "properties": {
          "timestamp": {
            "type": "date_nanos"
          }
        }
      }
```