### PR TITLE
Set event's Timestamp to DateTimePrecise.UtcNow

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/LoggerInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/LoggerInput.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
                 EventData eventEntry = new EventData()
                 {
                     ProviderName = string.IsNullOrEmpty(source) ? TraceTag : source,
-                    Timestamp = DateTime.UtcNow,
+                    Timestamp = DateTimePrecise.UtcNow,
                     Level = level
                 };
 

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/TraceInput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/TraceInput.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
                 EventData eventEntry = new EventData()
                 {
                     ProviderName = string.IsNullOrEmpty(source) ? TraceTag : source,
-                    Timestamp = DateTime.UtcNow,
+                    Timestamp = DateTimePrecise.UtcNow,
                     Level = ToEventLevel(level)
                 };
 


### PR DESCRIPTION
* Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging
* Microsoft.Diagnostics.EventFlow.Inputs.Trace
      - set event's Timestamp to DateTimePrecise.UtcNow (instead of DateTime.UtcNow). Now (maybe only on .net framework):
            - when there are multiple inputs that internally uses different way of setting Timestamp property there is mismatch of events ordered by Timestamp and their actual sequence
            - there are multiple events with same Timestamp

(Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter still uses DateTime.Now.I didn't change it because events rate is limited)