### PR TITLE
Fix issue 354

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/EventFlowJsonUtilities.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/EventFlowJsonUtilities.cs
@@ -4,16 +4,30 @@
 // ------------------------------------------------------------
 
 using Newtonsoft.Json;
+using System;
+using System.Dynamic;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Diagnostics.EventFlow
 {
     public static class EventFlowJsonUtilities
     {
-        public static JsonSerializerSettings DefaultSerializerSettings  { get; } =new JsonSerializerSettings()
+        private static Lazy<JsonSerializerSettings> settings = new Lazy<JsonSerializerSettings>(GetDefaultSerializerSettings, System.Threading.LazyThreadSafetyMode.PublicationOnly);
+
+        [Obsolete("Use GetDefaultSerializerSettings() instead")]
+        public static JsonSerializerSettings DefaultSerializerSettings => settings.Value;
+
+        public static JsonSerializerSettings GetDefaultSerializerSettings()
         {
-            NullValueHandling = NullValueHandling.Ignore,
-            DateFormatHandling = DateFormatHandling.IsoDateFormat,
-            ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-        };
+            var settings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+            };
+
+            settings.Converters.Add(new MemberInfoConverter());
+            return settings;
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/MemberInfoConverter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/MemberInfoConverter.cs
@@ -1,0 +1,76 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Microsoft.Diagnostics.EventFlow
+{
+#if NET471 || NETSTANDARD2_0
+    public class MemberInfoConverter : JsonConverter<MemberInfo>
+#else
+    public class MemberInfoConverter : JsonConverter
+#endif
+    {
+
+#if NET451 || NETSTANDARD1_6
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(MemberInfo).GetTypeInfo().IsAssignableFrom(objectType);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value != null && !(value is MemberInfo))
+            {
+                throw new JsonSerializationException($"{nameof(MemberInfoConverter)} cannot convert given value to JSON");
+            }
+
+            this.WriteJson(writer, (MemberInfo)value, serializer);
+        }
+#endif
+
+#if NET471 || NETSTANDARD2_0
+        public override MemberInfo ReadJson(JsonReader reader, Type objectType, MemberInfo existingValue, bool hasExistingValue, JsonSerializer serializer)
+#else
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+#endif
+        {
+            throw new NotImplementedException();
+        }
+
+#if NET471 || NETSTANDARD2_0
+        public override void WriteJson(JsonWriter writer, MemberInfo value, JsonSerializer serializer)
+#else
+        public void WriteJson(JsonWriter writer, MemberInfo value, JsonSerializer serializer)
+#endif
+        {
+            if (value == null)
+            {
+                writer.WriteValue(string.Empty);
+                return;
+            }
+
+            string fullName;
+#if NETSTANDARD1_6
+            Type parentType = value.DeclaringType;
+#else
+            Type parentType = value.ReflectedType;
+#endif
+
+            if (parentType == null)
+            {
+                fullName = value.Name;
+            }
+            else
+            {
+                fullName = parentType.FullName + "." + value.Name;
+            }
+
+            writer.WriteValue(fullName);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451;net471</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>
@@ -30,7 +30,7 @@
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="Validation" Version="2.4.18" />
-    <PaskageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PaskageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
@@ -43,9 +43,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
@@ -61,9 +61,9 @@
     <Reference Include="System.Web" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>netstandard1.6;net451;netstandard2.0;net471</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.EtwUtilities</AssemblyName>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.EtwUtilities</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Utilities;Event Tracing for Windows</PackageTags>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
@@ -40,7 +40,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
@@ -28,10 +28,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
   </ItemGroup>
 
-  <ItemGroup>    
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <Reference Include="System" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventDataExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventDataExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             public List<ShoeBoxRecord> records = new List<ShoeBoxRecord>();
         }
 
-        public static MessagingEventData ToMessagingEventData(this EventData eventData, out int messageSize)
+        public static MessagingEventData ToMessagingEventData(this EventData eventData, JsonSerializerSettings serializerSettings, out int messageSize)
         {
             IReadOnlyCollection<EventMetadata> metadataCollection;
             var sbEventData = eventData.TryGetMetadata("metric", out metadataCollection)
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             // If this turns out to consume significant CPU time, we could serialize the object "manually".
             // See https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.EventSource/EventSourceLogger.cs for an example.
             // This avoids the reflection cost that is associate with single-call SerializeObject approach
-            string eventDataSerialized = JsonConvert.SerializeObject(sbEventData, EventFlowJsonUtilities.DefaultSerializerSettings);
+            string eventDataSerialized = JsonConvert.SerializeObject(sbEventData, serializerSettings);
 
             byte[] messageBytes = Encoding.UTF8.GetBytes(eventDataSerialized);
             messageSize = messageBytes.Length;

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</AssemblyName>
-    <VersionPrefix>1.4.1</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Event Hub;Event Hubs</PackageTags>
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Validation" Version="2.4.18" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.1" />

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/HttpOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/HttpOutput.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             Initialize(configuration.DeepClone(), httpClient);
         }
 
+        public JsonSerializerSettings SerializerSettings { get; set; }
+
         private void Initialize(HttpOutputConfiguration configuration, Implementation.IHttpClient httpClient)
         {
             string errorMessage;
@@ -108,6 +110,8 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             {
                 this.httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
             }
+
+            SerializerSettings = EventFlowJsonUtilities.GetDefaultSerializerSettings();
         }
 
         public async Task SendEventsAsync(IReadOnlyCollection<EventData> events, long transmissionSequenceNumber, CancellationToken cancellationToken)
@@ -124,13 +128,13 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                 switch (configuration.Format) 
                 {
                     case HttpOutputFormat.Json:
-                        payload.Append(JsonConvert.SerializeObject(events, EventFlowJsonUtilities.DefaultSerializerSettings));
+                        payload.Append(JsonConvert.SerializeObject(events, SerializerSettings));
                         break;
 
                     case HttpOutputFormat.JsonLines:
                         foreach (EventData evt in events)
                         {
-                            payload.AppendLine(JsonConvert.SerializeObject(evt, EventFlowJsonUtilities.DefaultSerializerSettings));
+                            payload.AppendLine(JsonConvert.SerializeObject(evt, SerializerSettings));
                         }
                         break;
                 }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</AssemblyName>
-    <VersionPrefix>1.4.1</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;HttpOutput</PackageTags>
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Properties/AssemblyInfo.cs
@@ -17,3 +17,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("49a23dff-ce13-4413-a024-65247b30d09c")]
+
+[assembly: InternalsVisibleTo("Microsoft.Diagnostics.EventFlow.Outputs.Tests")]

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/StdOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/StdOutput.cs
@@ -19,12 +19,21 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
         public static readonly string TraceTag = nameof(StdOutput);
 
         private readonly IHealthReporter healthReporter;
+        private readonly Action<string> writeOutput;
 
         public StdOutput(IHealthReporter healthReporter)
         {
             Requires.NotNull(healthReporter, nameof(healthReporter));
             this.healthReporter = healthReporter;
             SerializerSettings = EventFlowJsonUtilities.GetDefaultSerializerSettings();
+            this.writeOutput = Console.WriteLine;
+        }
+
+        // Test constructor
+        internal StdOutput(IHealthReporter healthReporter, Action<string> outputWriter): this(healthReporter)
+        {
+            Requires.NotNull(outputWriter, nameof(outputWriter));
+            this.writeOutput = outputWriter;
         }
 
         public JsonSerializerSettings SerializerSettings { get; set; }
@@ -38,7 +47,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                     string eventString = JsonConvert.SerializeObject(evt, SerializerSettings);
                     string output = $"[{transmissionSequenceNumber}] {eventString}";
 
-                    Console.WriteLine(output);
+                    this.writeOutput(output);
                 }
                 return Task.FromResult(true);
             }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/StdOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/StdOutput.cs
@@ -24,7 +24,10 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
         {
             Requires.NotNull(healthReporter, nameof(healthReporter));
             this.healthReporter = healthReporter;
+            SerializerSettings = EventFlowJsonUtilities.GetDefaultSerializerSettings();
         }
+
+        public JsonSerializerSettings SerializerSettings { get; set; }
 
         public Task SendEventsAsync(IReadOnlyCollection<EventData> events, long transmissionSequenceNumber, CancellationToken cancellationToken)
         {
@@ -32,7 +35,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
             {
                 foreach (EventData evt in events)
                 {
-                    string eventString = JsonConvert.SerializeObject(evt, EventFlowJsonUtilities.DefaultSerializerSettings);
+                    string eventString = JsonConvert.SerializeObject(evt, SerializerSettings);
                     string output = $"[{transmissionSequenceNumber}] {eventString}";
 
                     Console.WriteLine(output);

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides types that simplify the use of EventFlow library by Microsoft Service Fabric services.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.5.1</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard2.0;net451;net471</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
@@ -29,8 +29,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
@@ -43,8 +43,8 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/JsonSerializationTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/JsonSerializationTests.cs
@@ -1,0 +1,33 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using Newtonsoft.Json;
+using Xunit;
+
+using Microsoft.Diagnostics.EventFlow.TestHelpers;
+
+namespace Microsoft.Diagnostics.EventFlow.Core.Tests
+{
+    public class JsonSerializationTests
+    {
+        [Fact]
+        public void SerializesMethodInfoAsFullyQualifiedName()
+        {
+            var obj = new
+            {
+                Name = "foo",
+                Method = typeof(JsonSerializationTests).GetMethod(nameof(SerializesMethodInfoAsFullyQualifiedName))
+            };
+
+            string objString = JsonConvert.SerializeObject(obj, EventFlowJsonUtilities.GetDefaultSerializerSettings());
+
+            Assert.Equal(
+            @"{
+                ""Name"":""foo"",
+                ""Method"":""Microsoft.Diagnostics.EventFlow.Core.Tests.JsonSerializationTests.SerializesMethodInfoAsFullyQualifiedName""
+            }".RemoveAllWhitespace(), objString);
+        }
+    }
+}

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
@@ -58,6 +58,7 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -28,17 +28,17 @@
 
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">    
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />    
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
   </ItemGroup>
 
@@ -59,7 +59,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.11" />
     <PackageReference Include="System.Reflection.Metadata" Version="[1.5.0,1.6.0)" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/ElasticSearchOutputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/ElasticSearchOutputTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
 
             using (var configFile = new TemporaryFile())
             {
-                var pipelineConfig = JsonConvert.SerializeObject(pipelineConfigObj, EventFlowJsonUtilities.DefaultSerializerSettings);
+                var pipelineConfig = JsonConvert.SerializeObject(pipelineConfigObj, EventFlowJsonUtilities.GetDefaultSerializerSettings());
 
                 configFile.Write(pipelineConfig);
                 var configBuilder = new ConfigurationBuilder();

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/HttpOutputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/HttpOutputTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
 
             using (var configFile = new TemporaryFile())
             {
-                var pipelineConfig = JsonConvert.SerializeObject(pipelineConfigObj, EventFlowJsonUtilities.DefaultSerializerSettings);
+                var pipelineConfig = JsonConvert.SerializeObject(pipelineConfigObj, EventFlowJsonUtilities.GetDefaultSerializerSettings());
 
                 configFile.Write(pipelineConfig);
                 var configBuilder = new ConfigurationBuilder();

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/StdOutputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/StdOutputTests.cs
@@ -4,8 +4,13 @@
 // ------------------------------------------------------------
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Moq;
 using Xunit;
+
+using Microsoft.Diagnostics.EventFlow.TestHelpers;
 
 namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
 {
@@ -33,6 +38,81 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
             });
 
             Assert.Equal("healthReporter", ex.ParamName);
+        }
+
+        [Fact]
+        public async Task MethodInfoIsSerializedAsFullyQualifiedName()
+        {
+            var healthReporter = new Mock<IHealthReporter>();
+
+            EventData e = new EventData();
+            e.ProviderName = "TestProvider";
+            e.Timestamp = new DateTimeOffset(2018, 1, 2, 14, 12, 0, TimeSpan.Zero);
+            e.Level = LogLevel.Warning;
+            e.Payload.Add("Method", typeof(StdOutputTests).GetMethod(nameof(MethodInfoIsSerializedAsFullyQualifiedName)));
+
+            string actualOutput = null;
+            StdOutput stdOutput = new StdOutput(healthReporter.Object, s => actualOutput = s);
+            await stdOutput.SendEventsAsync(new EventData[] { e }, 34, CancellationToken.None);
+
+            string expecteOutput = @"[34]
+                {
+                    ""Timestamp"":""2018-01-02T14:12:00+00:00"",
+                    ""ProviderName"":""TestProvider"",
+                    ""Level"":3,
+                    ""Keywords"":0,
+                    ""Payload"":{""Method"":""Microsoft.Diagnostics.EventFlow.Outputs.Tests.StdOutputTests.MethodInfoIsSerializedAsFullyQualifiedName""}
+                }
+            ";
+            Assert.Equal(expecteOutput.RemoveAllWhitespace(), actualOutput.RemoveAllWhitespace());
+            healthReporter.Verify(hr => hr.ReportWarning(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            healthReporter.Verify(hr => hr.ReportProblem(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UsesCustomJsonSerializerSettings()
+        {
+            var healthReporter = new Mock<IHealthReporter>();
+
+            EventData e = new EventData();
+            e.ProviderName = "TestProvider";
+            e.Timestamp = new DateTimeOffset(2018, 1, 2, 14, 12, 0, TimeSpan.Zero);
+            e.Level = LogLevel.Warning;
+            e.Payload.Add("InfinityProperty", Double.PositiveInfinity);
+
+            string actualOutput = null;
+            StdOutput stdOutput = new StdOutput(healthReporter.Object, s => actualOutput = s);
+            await stdOutput.SendEventsAsync(new EventData[] { e }, 34, CancellationToken.None);
+
+            string expecteOutput = @"[34]
+                {
+                    ""Timestamp"":""2018-01-02T14:12:00+00:00"",
+                    ""ProviderName"":""TestProvider"",
+                    ""Level"":3,
+                    ""Keywords"":0,
+                    ""Payload"":{""InfinityProperty"":""Infinity""}
+                }
+            ";
+            Assert.Equal(expecteOutput.RemoveAllWhitespace(), actualOutput.RemoveAllWhitespace());
+            healthReporter.Verify(hr => hr.ReportWarning(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            healthReporter.Verify(hr => hr.ReportProblem(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+            // Now verify changing serializer settings is effective
+            stdOutput.SerializerSettings.FloatFormatHandling = FloatFormatHandling.DefaultValue;
+            await stdOutput.SendEventsAsync(new EventData[] { e }, 36, CancellationToken.None);
+
+            expecteOutput = @"[36]
+                {
+                    ""Timestamp"":""2018-01-02T14:12:00+00:00"",
+                    ""ProviderName"":""TestProvider"",
+                    ""Level"":3,
+                    ""Keywords"":0,
+                    ""Payload"":{""InfinityProperty"":0.0}
+                }
+            ";
+            Assert.Equal(expecteOutput.RemoveAllWhitespace(), actualOutput.RemoveAllWhitespace());
+            healthReporter.Verify(hr => hr.ReportWarning(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            healthReporter.Verify(hr => hr.ReportProblem(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/test/TestHelpers/StringExtensions.cs
+++ b/test/TestHelpers/StringExtensions.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Text;
+
+namespace Microsoft.Diagnostics.EventFlow.TestHelpers
+{
+    public static class StringExtensions
+    {
+        public static string RemoveAllWhitespace(this string s)
+        {
+            if (s == null) return null;
+            if (s.Length == 0) return s;
+
+            StringBuilder sb = new StringBuilder(s.Length);
+            foreach(char c in s) 
+            { 
+                if (!Char.IsWhiteSpace(c))
+                {
+                    sb.Append(c);
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Adds a serialization converter that special-cases all types deriving from reflection library's `MemberInfo`, which will be represented by the member fully-qualified name (e.g. `System.Object.GetHashCode`). This is to avoid serializing the whole reflection graph when using JSON serialization.

Also adds ability to change the JSON serialization settings for `EventHubOutput`, `HttpOutput`, `OmsOutput` (Azure Monitor), and `StdOutput`.

Updates Newtonsoft JSON library dependency to 11.0.2, and, correspondingly, `Microsoft.Configuration.Abstractions` dependency to 2.2.0

Fixes [issue 354](https://github.com/Azure/diagnostics-eventflow/issues/354)