### PR TITLE
Aded Json Converters for IPEndpoint and IPAddress

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/EventFlowJsonUtilities.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/EventFlowJsonUtilities.cs
@@ -3,10 +3,10 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-using Newtonsoft.Json;
 using System;
-using System.Dynamic;
-using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
+
+using Microsoft.Diagnostics.EventFlow.JsonConverters;
 
 namespace Microsoft.Diagnostics.EventFlow
 {
@@ -27,6 +27,8 @@ namespace Microsoft.Diagnostics.EventFlow
             };
 
             settings.Converters.Add(new MemberInfoConverter());
+            settings.Converters.Add(new IPEndpointConverter());
+            settings.Converters.Add(new IPAddressConverter());
             return settings;
         }
     }

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/IPAddressConverter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/IPAddressConverter.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Net;
+using Newtonsoft.Json;
+
+namespace Microsoft.Diagnostics.EventFlow.JsonConverters
+{
+    internal class IPAddressConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IPAddress);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            // this converter used only for Serialization
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/IPEndpointConverter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/IPEndpointConverter.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Net;
+#if NET451 || NETSTANDARD1_6
+using System.Reflection;
+#endif
+using Newtonsoft.Json;
+
+namespace Microsoft.Diagnostics.EventFlow.JsonConverters
+{
+    internal class IPEndpointConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+#if NET451 || NETSTANDARD1_6
+            return typeof(EndPoint).GetTypeInfo().IsAssignableFrom(objectType);
+#else
+            return typeof(EndPoint).IsAssignableFrom(objectType);
+#endif
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            // this converter used only for Serialization
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+    }
+
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/MemberInfoConverter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/MemberInfoConverter.cs
@@ -7,7 +7,7 @@ using System;
 using System.Reflection;
 using Newtonsoft.Json;
 
-namespace Microsoft.Diagnostics.EventFlow
+namespace Microsoft.Diagnostics.EventFlow.JsonConverters
 {
 #if NET471 || NETSTANDARD2_0
     public class MemberInfoConverter : JsonConverter<MemberInfo>

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451;net471</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/JsonSerializationTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/JsonSerializationTests.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System.Net;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -27,6 +28,49 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
             @"{
                 ""Name"":""foo"",
                 ""Method"":""Microsoft.Diagnostics.EventFlow.Core.Tests.JsonSerializationTests.SerializesMethodInfoAsFullyQualifiedName""
+            }".RemoveAllWhitespace(), objString);
+        }
+
+        [Fact]
+        public void SerializesIPAddress()
+        {
+            var ipAddress = IPAddress.Parse("127.0.0.1");
+
+            var obj = new
+            {
+                IpAddress = ipAddress
+            };
+
+            // ensure assumption that IPAddress cannot be serialized with default JSON settings
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(obj));
+
+            string objString = JsonConvert.SerializeObject(obj, EventFlowJsonUtilities.GetDefaultSerializerSettings());
+
+            Assert.Equal(
+            @"{
+                ""IpAddress"":""127.0.0.1""
+            }".RemoveAllWhitespace(), objString);
+        }
+
+        [Fact]
+        public void SerializesIPEndPoint()
+        {
+            var ipAddress = IPAddress.Parse("127.0.0.1");
+            var endpoint = new IPEndPoint(ipAddress, 5000);
+
+            var obj = new
+            {
+                Endpoint = endpoint
+            };
+
+            // ensure assumption that IPEndPoint cannot be serialized with default JSON settings
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(obj));
+
+            string objString = JsonConvert.SerializeObject(obj, EventFlowJsonUtilities.GetDefaultSerializerSettings());
+
+            Assert.Equal(
+            @"{
+                ""Endpoint"":""127.0.0.1:5000""
             }".RemoveAllWhitespace(), objString);
         }
     }


### PR DESCRIPTION
Some libraries (for example, [Orleans](https://github.com/dotnet/orleans/blob/master/src/Orleans.Core/Networking/ConnectionLogScope.cs)) may attach logging scopes that contain `IPEndpoint` or `IPAddress` types. 

Both types cannot be serialized with default JSON settings and if EventFlow is configured to read `Microsoft.Extension.Logging` input with those scopes attached it will fail to process those events.

This PR adds simple JSON converters that will call `.ToString()` methods on those types instead of trying to serialize them as Json objects.