### PR TITLE
Build updates

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DateTimePrecise.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DateTimePrecise.cs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 
 using System;
-#if NET451 || NET471
+#if NET452 || NET471
 using System.Runtime.InteropServices;
 #endif
 
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.EventFlow
 {
     public static class DateTimePrecise
     {
-#if NET451 || NET471
+#if NET452 || NET471
         [DllImport("Kernel32.dll", CallingConvention = CallingConvention.Winapi)]
         private static extern void GetSystemTimePreciseAsFileTime(out long filetime);
 
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.EventFlow
         {
             get
             {
-#if NET451 || NET471
+#if NET452 || NET471
                 if (UseSystemTimePrecise)
                 {
                     GetSystemTimePreciseAsFileTime(out var filetime);

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporters/CsvHealthReporter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/HealthReporters/CsvHealthReporter.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Validation;
 
-#if NET451
+#if NET452
 using System.Web;
 #else
 using System.Reflection;
@@ -534,7 +534,7 @@ namespace Microsoft.Diagnostics.EventFlow.HealthReporters
             }
 
             string basePath;
-#if NET451
+#if NET452
             if (HttpContext.Current != null && HttpContext.Current.Server != null)
             {
                 basePath = HttpContext.Current.Server.MapPath("~/App_Data");

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/IPEndpointConverter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/IPEndpointConverter.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Net;
-#if NET451 || NETSTANDARD1_6
+#if NET452 || NETSTANDARD1_6
 using System.Reflection;
 #endif
 using Newtonsoft.Json;
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.EventFlow.JsonConverters
     {
         public override bool CanConvert(Type objectType)
         {
-#if NET451 || NETSTANDARD1_6
+#if NET452 || NETSTANDARD1_6
             return typeof(EndPoint).GetTypeInfo().IsAssignableFrom(objectType);
 #else
             return typeof(EndPoint).IsAssignableFrom(objectType);

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/MemberInfoConverter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/MemberInfoConverter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.EventFlow.JsonConverters
 #endif
     {
 
-#if NET451 || NETSTANDARD1_6
+#if NET452 || NETSTANDARD1_6
         public override bool CanConvert(Type objectType)
         {
             return typeof(MemberInfo).GetTypeInfo().IsAssignableFrom(objectType);

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/UtcMidnightNotifier.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/UtcMidnightNotifier.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Threading;
 using Microsoft.Diagnostics.EventFlow.HealthReporters;
-#if NET451
+#if NET452
 using Microsoft.Win32;
 #endif
 
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.EventFlow
             CreateNewTimer();
 
             // TODO: Find an event to subscribe for .NET Core application when system time is changed.
-#if NET451
+#if NET452
             SystemEvents.TimeChanged += OnSystemTimeChanged;
 #endif
         }

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>1.10.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net451;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net452;net471</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Core</PackageId>
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Web" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
@@ -4,10 +4,10 @@
     <Description>Provides utility classes for processing data from Event Tracing for Windows (ETW) providers.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netstandard2.0;net471</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.EtwUtilities</AssemblyName>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.EtwUtilities</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Utilities;Event Tracing for Windows</PackageTags>
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[1.1.1,2.0)" />

--- a/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/Microsoft.Diagnostics.EventFlow.FilterParserGenerator.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.FilterParserGenerator/Microsoft.Diagnostics.EventFlow.FilterParserGenerator.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an implementation of Application Insights telemetry processor that feeds Application Insights telemetry into EventFlow pipeline. 
     This allows sending diagnostics data from applications instrumented with Application Insights to destinations other than Application Insights service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.5.1</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights</PackageId>
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource/Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.DiagnosticSource.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource</AssemblyName>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;DiagnosticSource</PackageTags>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an input implementation for capturing diagnostics data from Event Tracing for Windows (ETW) providers.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Etw</AssemblyName>
-    <VersionPrefix>1.4.2</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.Etw</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;ETW;Event Tracing for Windows</PackageTags>
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.11" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Log4net/Microsoft.Diagnostics.EventFlow.Inputs.Log4net.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Log4net/Microsoft.Diagnostics.EventFlow.Inputs.Log4net.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Inputs.Log4net infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Log4net</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.Log4net</PackageId>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLoggerScope.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLoggerScope.cs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 
 using System;
-#if NET451
+#if NET452
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Messaging;
 #else
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
         public Object State { get; private set; }
         public EventFlowLoggerScope Parent { get; private set; }
 
-#if NET451
+#if NET452
         // LogicalCallContext will flow through cross app domain calls.
         // Thus we make the FieldKey domain specific and wrap the EventFlowLoggerScope in ObjectHandle to avoid exceptions when cross app domain call happens.
         private static readonly string FieldKey = $"{typeof(EventFlowLoggerScope).FullName}_{AppDomain.CurrentDomain.Id}";

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an input implementation for capturing diagnostics data sourced through Microsoft.Extensions.Logging.ILogger</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net452</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</AssemblyName>
-    <VersionPrefix>1.4.5</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;MicrosoftLogging</PackageTags>
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\Microsoft.Diagnostics.EventFlow.Core\Microsoft.Diagnostics.EventFlow.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' Or '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' Or '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
   </ItemGroup>
 
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.NLog/Microsoft.Diagnostics.EventFlow.Inputs.NLog.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.NLog/Microsoft.Diagnostics.EventFlow.Inputs.NLog.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through NLog library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net452</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.NLog</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.NLog</PackageId>
@@ -15,7 +15,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net451' ">true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -27,7 +27,7 @@
     <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter/Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing data from Windows performance counters.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter</PackageId>
@@ -27,7 +27,7 @@
     <ProjectReference Include="..\Microsoft.Diagnostics.EventFlow.Core\Microsoft.Diagnostics.EventFlow.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Serilog/Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data created via Serilog library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Serilog</AssemblyName>
@@ -31,7 +31,7 @@
     <PackageReference Include="Serilog" Version="2.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/Microsoft.Diagnostics.EventFlow.Inputs.Trace.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Trace/Microsoft.Diagnostics.EventFlow.Inputs.Trace.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Trace infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Trace</AssemblyName>
-    <VersionPrefix>1.4.2</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.Trace</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;Trace</PackageTags>
@@ -29,7 +29,7 @@
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights/Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides an output implementation that sends diagnostics data to Microsoft Application Insights service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights</PackageId>
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an output implementation that sends diagnostics data to Azure Event Hubs.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</AssemblyName>
-    <VersionPrefix>1.5.1</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Event Hub;Event Hubs</PackageTags>
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput/Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an output implementation that sends diagnostics data to webserver using HTTP.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</AssemblyName>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;HttpOutput</PackageTags>
@@ -29,7 +29,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.Oms/Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an output implementation that sends diagnostics data Azure Monitor Logs Service.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Oms</AssemblyName>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.AzureMonitorLogs</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Azure Monitor Logs;Log Analytics</PackageTags>
@@ -29,7 +29,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput/Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an output implementation that sends diagnostics data to standard output stream (useful for debugging purposes).</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.StdOutput</AssemblyName>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.StdOutput</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs</PackageTags>
@@ -29,7 +29,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage/Microsoft.Diagnostics.EventFlow.Outputs.TableStorage.csproj
@@ -4,9 +4,9 @@
     <Description>Provides an output implementation that sends diagnostics data to Azure Table Storage.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.TableStorage</AssemblyName>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>    
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -22,7 +22,7 @@
     <PackageReference Include="WindowsAzure.Storage" Version="7.2.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.ServiceFabric/Microsoft.Diagnostics.EventFlow.ServiceFabric.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Provides types that simplify the use of EventFlow library by Microsoft Service Fabric services.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net451;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452;net471</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.ServiceFabric</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.1" />

--- a/src/Microsoft.Diagnostics.EventFlow.Signing/Microsoft.Diagnostics.EventFlow.Signing.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Signing/Microsoft.Diagnostics.EventFlow.Signing.csproj
@@ -64,25 +64,25 @@
   -->
   <Target Name="MoveAssembliesBeforeSigning" Condition="'$(SignType)'!=''" BeforeTargets="SignFiles">
     <ItemGroup>
-      <FullAssemblies Include="..\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Core.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.EtwUtilities\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.EtwUtilities.dll;
+      <FullAssemblies Include="..\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Core.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.EtwUtilities\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.EtwUtilities.dll;
                                ..\Microsoft.Diagnostics.EventFlow.Inputs.EventSource\bin\$(Configuration)\net46\Microsoft.Diagnostics.EventFlow.Inputs.EventSource.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.Etw\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.Etw.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.Trace\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.Trace.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.Serilog\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.Serilog.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.Log4net\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.Log4net.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Inputs.NLog\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Inputs.NLog.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Outputs.Oms\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Outputs.Oms.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.Outputs.TableStorage\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Outputs.TableStorage.dll;
-                               ..\Microsoft.Diagnostics.EventFlow.ServiceFabric\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll;" />
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.Etw\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.Etw.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.Trace\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.Trace.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.Serilog\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.Serilog.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.Log4net\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.Log4net.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Inputs.NLog\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Inputs.NLog.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Outputs.Oms\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Outputs.Oms.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.Outputs.TableStorage\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Outputs.TableStorage.dll;
+                               ..\Microsoft.Diagnostics.EventFlow.ServiceFabric\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll;" />
       <Full471Assemblies Include="..\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\net471\Microsoft.Diagnostics.EventFlow.Core.dll;
                                ..\Microsoft.Diagnostics.EventFlow.EtwUtilities\bin\$(Configuration)\net471\Microsoft.Diagnostics.EventFlow.EtwUtilities.dll;
                                ..\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch\bin\$(Configuration)\net471\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.dll;
@@ -138,25 +138,25 @@
   
   <Target Name="CopySignedAssembliesBack" Condition="'$(SignType)'!=''" AfterTargets="SignFiles">
     <!--Full framework assemblies-->
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Core.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.EtwUtilities.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.EtwUtilities\bin\$(Configuration)\net451"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Core.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.EtwUtilities.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.EtwUtilities\bin\$(Configuration)\net452"/>
     <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.EventSource.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.EventSource\bin\$(Configuration)\net46"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.Etw.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.Etw\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.Trace.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.Trace\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.Serilog.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.Serilog\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.Log4net.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.Log4net\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.NLog.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.NLog\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.Oms.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.Oms\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.TableStorage.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.TableStorage\bin\$(Configuration)\net451"/>
-    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.ServiceFabric\bin\$(Configuration)\net451"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.Etw.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.Etw\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.DiagnosticSource\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.Trace.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.Trace\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.Serilog.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.Serilog\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.ApplicationInsights\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.Log4net.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.Log4net\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Inputs.NLog.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Inputs.NLog\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.Oms.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.Oms\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.Outputs.TableStorage.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Outputs.TableStorage\bin\$(Configuration)\net452"/>
+    <Copy SourceFiles="$(OutputPath)\full\Microsoft.Diagnostics.EventFlow.ServiceFabric.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.ServiceFabric\bin\$(Configuration)\net452"/>
     <!--.Net Framework 4.7.1 assemblies-->
     <Copy SourceFiles="$(OutputPath)\full471\Microsoft.Diagnostics.EventFlow.Core.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\net471"/>
     <Copy SourceFiles="$(OutputPath)\full471\Microsoft.Diagnostics.EventFlow.EtwUtilities.dll" DestinationFolder="..\Microsoft.Diagnostics.EventFlow.EtwUtilities\bin\$(Configuration)\net471"/>

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DateTimePreciseTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DateTimePreciseTests.cs
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-#if !NETCOREAPP1_0
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -54,4 +53,3 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
         }
     }
 }
-#endif

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/MetadataTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/MetadataTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
             Assert.Equal("200 OK", rd.ResponseCode);
 
             // Note the TimeSpan.FromMilliseconds will round to the nearest millisecond on everything older than .NET Core 3.0
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             Assert.Equal(34.7, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
 #else
             Assert.Equal(35, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
@@ -155,7 +155,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
             eventData.Payload["duration"] = 65.7;
             result = RequestData.TryGetData(eventData, requestMetadata, out rd);
             Assert.Equal(DataRetrievalStatus.Success, result.Status);
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             Assert.Equal(65.7, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
 #else
             Assert.Equal(66, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0;net471;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;net471;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -35,16 +35,16 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp3.0' " >
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' " >
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
   </ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.FunctionalTests.HealthReporterBuster/Microsoft.Diagnostics.EventFlow.FunctionalTests.HealthReporterBuster.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.FunctionalTests.HealthReporterBuster/Microsoft.Diagnostics.EventFlow.FunctionalTests.HealthReporterBuster.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Diagnostics.EventFlow.FunctionalTests.HealthReporterBuster</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.FunctionalTests.HealthReporterBuster</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -35,7 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\net451\Microsoft.Diagnostics.EventFlow.Core.dll">
+    <Reference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Core\bin\$(Configuration)\net452\Microsoft.Diagnostics.EventFlow.Core.dll">
       <Name>Microsoft.Diagnostics.EventFlow.Core</Name>
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">

--- a/test/Microsoft.Diagnostics.EventFlow.FunctionalTests.HealthReporterBuster/packages.config
+++ b/test/Microsoft.Diagnostics.EventFlow.FunctionalTests.HealthReporterBuster/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Extensions.Configuration" version="1.1.1" targetFramework="net451" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.1.1" targetFramework="net451" />
-  <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
-  <package id="System.IO" version="4.1.0" targetFramework="net451" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net451" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net451" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net451" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net451" />
-  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net451" />
-  <package id="System.Threading" version="4.0.11" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Configuration" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
+  <package id="System.IO" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net452" />
 </packages>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EventSourceInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EventSourceInputTests.cs
@@ -12,9 +12,7 @@ using System.Threading.Tasks;
 using Moq;
 using Xunit;
 
-#if !NETCOREAPP1_0
 using System.Collections.ObjectModel;
-#endif
 
 using Microsoft.Diagnostics.EventFlow.Inputs;
 using Microsoft.Diagnostics.EventFlow.Configuration;
@@ -126,7 +124,6 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
         }
 
         // High-precision event timestamping is availabe on .NET 4.6+ and .NET Core 2.0+
-#if !NETCOREAPP1_0
         [Fact]
         public void MeasuresEventTimeWithHighResolution()
         {
@@ -160,7 +157,6 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
             // Event timestamps should have less than 1 ms resolution and thus should all be different
             Assert.Equal(8, eventTimes.Distinct().Count());
         }
-#endif
 
         [Fact]
         public void CapturesEventsFromSourcesIdentifiedByNamePrefix()
@@ -233,7 +229,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
                 Assert.Equal("EventCounters", data.Payload["EventName"]);
                 Assert.Equal("testCounter", data.Payload["Name"]);
                 Assert.Equal(2, data.Payload["Count"]);
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
                 Assert.Equal((double)5, data.Payload["Max"]);
                 Assert.Equal((double)1, data.Payload["Min"]);
 #else
@@ -425,9 +421,6 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
             }
         }
 
-        // Enabling events with different levels and keywords does not work on .NET Core 1.1. and 2.0
-        // (following up with .NET team to see if there is something we can do about it)
-#if !NETCOREAPP1_0
         [Fact]
         public void CanEnableSameSourceWithDifferentLevelsAndKeywords()
         {
@@ -463,7 +456,6 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
                 healthReporterMock.Verify(o => o.ReportProblem(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
             }
         }
-#endif
 
         [Fact]
         public void CanReadKeywordsInHexFormat()

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/LoggerInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/LoggerInputTests.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-#if NETCOREAPP2_1 || NETCOREAPP3_0
+#if NETCOREAPP2_1 || NETCOREAPP3_1
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 #endif
@@ -450,7 +450,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
             }
         }
 
-#if NETCOREAPP2_1 || NETCOREAPP3_0
+#if NETCOREAPP2_1 || NETCOREAPP3_1
         [Fact]
         public async Task LoggerCanBeEnabledFromILoggingBuilder()
         {

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -35,14 +35,14 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.6.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -56,6 +56,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.11" />
     <PackageReference Include="System.Reflection.Metadata" Version="[1.5.0,1.6.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net471;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net471;netcoreapp3.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -33,16 +33,12 @@
     <Reference Include="Microsoft.CSharp" />    
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-  </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.6.0" />

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/TraceInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/TraceInputTests.cs
@@ -257,7 +257,6 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
             }
         }
 
-#if !NETCOREAPP1_0
         [Fact]
         public void TraceInputShouldOverrideTraceTransfer()
         {
@@ -305,7 +304,6 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
                     Times.Exactly(1));
             }
         }
-#endif
 
         private static string GetRandomString()
         {

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46;net471;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net46;net471;netcoreapp3.1</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">2.0</RuntimeFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>


### PR DESCRIPTION
- Build .NET 4.5.2 binaries instead of .NET 4.5.1
- Test on supported frameworks (replacing EOL frameworks)