### PR TITLE
Upgrade log4net dependency

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Log4net/Microsoft.Diagnostics.EventFlow.Inputs.Log4net.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Log4net/Microsoft.Diagnostics.EventFlow.Inputs.Log4net.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an input implementation for capturing diagnostics data sourced through System.Diagnostics.Inputs.Log4net infrastructure.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net452;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Log4net</AssemblyName>
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net46;net471;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net46;net471;netcoreapp3.1;net5.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests</AssemblyName>


### PR DESCRIPTION
Also enables tests on .NET 5 for all the components of the EventFlow suite