### PR TITLE
[WIP] (Question on customizing ETW input) - ETW/MsgPack input based off StandardTraceEventSession input

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.11" />
+    <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/MsgPackTraceEventSession.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/MsgPackTraceEventSession.cs
@@ -1,0 +1,166 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using MsgPack.Serialization;
+using Microsoft.Diagnostics.EventFlow.Utilities.Etw;
+
+namespace Microsoft.Diagnostics.EventFlow.Inputs
+{
+    internal class MsgPackTraceEventSession : StandardTraceEventSession
+    {
+
+        /// <summary>
+        /// MsgPackTraceEventSession allows to decode MsgPack-encoded binary events.
+        /// </summary>
+        /// <param name="sessionNamePrefix">See @base</param>
+        /// <param name="cleanupOldSessions">See @base</param>
+        /// <param name="reuseExisting">See @base</param>
+        /// <param name="healthReporter">See @base</param>
+        public MsgPackTraceEventSession(string sessionNamePrefix, bool cleanupOldSessions, bool reuseExisting, IHealthReporter healthReporter) :
+            base(sessionNamePrefix, cleanupOldSessions, reuseExisting, healthReporter)
+        {
+        }
+
+        /// <summary>
+        /// Convert TraceEvent in MsgPack format to EventData
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="reporter"></param>
+        /// <returns></returns>
+        internal static EventData DecodeMessagePack(TraceEvent data, IHealthReporter reporter)
+        {
+            EventData eventData = new EventData
+            {
+                ProviderName = data.ProviderName,
+                Timestamp = data.TimeStamp,
+                Level = (LogLevel)data.Level,
+                Keywords = (long)data.Keywords,
+            };
+
+            if (data.EventDataLength==0)
+            {
+                reporter.ReportProblem("MsgPack decoding failed: empty payload!");
+                return eventData;
+            }
+
+            byte[] managedArray = new byte[data.EventDataLength];
+            Marshal.Copy(data.DataStart, managedArray, 0, data.EventDataLength);
+
+            try
+            {
+                var obj = MessagePackSerializer.UnpackMessagePackObject(managedArray);
+                if (obj.IsDictionary)
+                {
+                    foreach (var kv in obj.AsDictionary())
+                    {
+                        var key = kv.Key.AsString();
+                        object val = null;
+                        switch (Type.GetTypeCode(kv.Value.UnderlyingType))
+                        {
+                            case TypeCode.String:
+                                val = kv.Value.AsString();
+                                break;
+
+                            case TypeCode.Boolean:
+                                val = kv.Value.AsBoolean();
+                                break;
+
+                            case TypeCode.Decimal:
+                                val = kv.Value.AsInt64();
+                                break;
+
+                            case TypeCode.Int16:
+                                val = kv.Value.AsInt16();
+                                break;
+
+                            case TypeCode.Int32:
+                                val = kv.Value.AsInt32();
+                                break;
+
+                            case TypeCode.Int64:
+                                val = kv.Value.AsInt64();
+                                break;
+
+                            case TypeCode.UInt16:
+                                val = kv.Value.AsUInt16();
+                                break;
+
+                            case TypeCode.UInt32:
+                                val = kv.Value.AsUInt32();
+                                break;
+
+                            case TypeCode.UInt64:
+                                val = kv.Value.AsUInt64();
+                                break;
+
+                            case TypeCode.Double:
+                                val = kv.Value.AsDouble();
+                                break;
+
+                            case TypeCode.Single:
+                                val = kv.Value.AsSingle();
+                                break;
+
+                            default:
+                                reporter.ReportWarning("Unknown type: " + kv.GetType());
+                                val = kv.Value.ToString();
+                                break;
+                        }
+                        eventData.Payload[key] = val;
+                    }
+                }
+                else
+                {
+                    eventData.Payload["Message"] = obj.ToString();
+                }
+
+            }
+            catch (ArgumentNullException ex)
+            {
+                reporter.ReportProblem("MsgPack decoding failed: " + ex.ToString());
+                return eventData;
+            };
+
+            return eventData;
+        }
+
+        /// <summary>
+        /// Process incoming ETW-MsgPack events
+        /// </summary>
+        /// <param name="onEvent"></param>
+        public override void Process(Action<EventData> onEvent)
+        {
+            if (this.inner == null)
+            {
+                throw new ObjectDisposedException(nameof(StandardTraceEventSession));
+            }
+
+            if (onEvent == null)
+            {
+                throw new ArgumentNullException(nameof(onEvent));
+            }
+
+            if (!isProcessing)
+            {
+                isProcessing = true;
+                this.inner.Source.AllEvents += (traceEvent) =>
+                {
+                    if (!TplActivities.TplEventSourceGuid.Equals(traceEvent.ProviderGuid))
+                    {
+                        /* TODO: For forward protocol where one single traceEvent contains
+                         * several events we need to extract them and forward individually
+                         */
+                        onEvent(DecodeMessagePack(traceEvent, this.healthReporter));
+                    }
+                };
+                this.inner.Source.Process();
+            }
+        }
+
+    }
+
+}

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/StandardTraceEventSession.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.Etw/StandardTraceEventSession.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
 {
     internal class StandardTraceEventSession : ITraceEventSession
     {
-        private TraceEventSession inner;
-        private bool isProcessing;
-        private IHealthReporter healthReporter;
+        protected TraceEventSession inner;
+        protected bool isProcessing;
+        protected IHealthReporter healthReporter;
 
         public StandardTraceEventSession(string sessionNamePrefix, bool cleanupOldSessions, bool reuseExisting, IHealthReporter healthReporter)
         {
@@ -72,7 +72,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
             this.inner.EnableProvider(providerName, maximumEventLevel, enabledKeywords);
         }
 
-        public void Process(Action<EventData> onEvent)
+        public virtual void Process(Action<EventData> onEvent)
         {
             if (this.inner == null)
             {


### PR DESCRIPTION
Greetings!

I would like to get some feedback and suggestions on how to implement the decoding of ETW events that are encoded in MsgPack. In some flows in Azure flows we utilize this encoding (MsgPack), which is neither Manifest nor TraceLogging Dynamic, but rather carries MsgPack-encoded payload that is generated by the application at runtime.

I implemented the payload decoder based off standard `EtwInput.cs`.

It required a few modifications:

- configuration flag **encoding:  MsgPack** that allows to specify that the incoming events should be decoded as MsgPack. Example config:

```json
{
  "inputs": [
    {
        "type": "ETW",
        "sessionNamePrefix": "OpenTelemetry",
        "cleanupOldSessions": true,
        "reuseExistingSession": true,
        "encoding":  "MsgPack",
        "providers": [
            {
                "providerName": "OpenTelemetry-ETW-MsgPack"
            }
        ]
    }
  ],
    "outputs": [
        {
            "type": "StdOutput"
        }
    ],
  "schemaVersion": "2016-08-11"
}
```

- had to change the `Process()` method signature to `public virtual void Process(Action<EventData> onEvent)`, in order to allow for a custom decoder implementation in `MsgPackTraceEventSession`. I am not sure about performance implications of that.

- changed a few class members from `private` to `protected`, to allow the `MsgPackTraceEventSession` inherit from the base `StandardTraceEventSession`

Eventual goal is to allow OpenTelemetry **C++ SDK** to emit ETW events using either TraceLoggingDynamic (StandardTraceEventSession) or ETW/MsgPack (MsgPackTraceEventSession), for easy integration between OpenTelemetry **C++ SDK** running on Windows with EventFlow, using EventFlow as a debugging / diagnostics tool, as well as forwarder to Azure Monitor, Application Insights, plain stdout, etc.

Is there a better / alternate approach available, maybe some extension point that would've allowed me to register a custom callback / decoder? Activity related to https://github.com/open-telemetry/opentelemetry-cpp/issues/326 and PR https://github.com/open-telemetry/opentelemetry-cpp/pull/519

Thank you!