### PR TITLE
Updated EventHub output to use Azure.* packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,7 +852,11 @@ This output writes data to a webserver using diffent encoding methods (Json or J
 ### Event Hub
 *Nuget Package*: [**Microsoft.Diagnostics.EventFlow.Outputs.EventHub**](https://www.nuget.org/packages/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/)
 
-This output writes data to the [Azure Event Hub](https://azure.microsoft.com/en-us/documentation/articles/event-hubs-overview/). Here is an example showing all possible settings:
+> **BREAKING CHANGE**: Starting from version `2.0.0` this package targets _only_ `netstandard2.0`.
+
+This output writes data to the [Azure Event Hub](https://azure.microsoft.com/en-us/documentation/articles/event-hubs-overview/).
+
+Here is an example showing configuration using connection string:
 ```jsonc
 {
     "type": "EventHub",
@@ -860,12 +864,29 @@ This output writes data to the [Azure Event Hub](https://azure.microsoft.com/en-
     "connectionString": "Endpoint=sb://<myEventHubNamespace>.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=<MySharedAccessKey>"
 }
 ```
+
+Here is an example showing configuration using Azure Identity:
+```jsonc
+{
+    "type": "EventHub",
+    "useAzureIdentity": true,
+    "fullyQualifiedNamespace": "<myEventHubNamespace>.servicebus.windows.net",
+    "eventHubName": "myEventHub"
+}
+```
+
 | Field | Values/Types | Required | Description |
 | :---- | :-------------- | :------: | :---------- |
 | `type` | "EventHub" | Yes | Specifies the output type. For this output, it must be "EventHub". |
-| `eventHubName` | event hub name | No | Specifies the name of the event hub. |
-| `connectionString` | connection string | Yes | Specifies the connection string for the event hub. The corresponding shared access policy must have send permission. If the event hub name does not appear in the connection string, then it must be specified in the eventHubName field. |
+| `connectionString` | connection string | Yes(*) | Specifies the connection string for the event hub. The corresponding shared access policy must have send permission. If the event hub name does not appear in the connection string, then it must be specified in the eventHubName field. |
+| `eventHubName` | event hub name | No(**)  | Specifies the name of the event hub. |
+| `useAzureIdentity` | boolean | Yes(*) | Specifies that Event Hub client will be using Azure Identity for authentication. The identity (managed of user) must have assigned policy with send permission. |
+| `fullyQualifiedNamespace` | string | Yes(**) | Specifies the root vent hub namespace. Should be a fully qualified name, i.e. `<namespace>.servicebus.windows.net`. |
 | `partitionKeyProperty` | string | No | The name of the event property that will be used as the PartitionKey for the Event Hub events. |
+
+(*) Either `connectionString` or `useAzureIdentity` must be specified. `useAzureIdentity` takes precedence.
+
+(**) When `useAzureIdentity` is set to `true` then both `eventHubName` and `fullyQualifiedNamespace` must be specified.
 
 [**Back to Topics**](#topics)
 

--- a/README.md
+++ b/README.md
@@ -852,8 +852,6 @@ This output writes data to a webserver using diffent encoding methods (Json or J
 ### Event Hub
 *Nuget Package*: [**Microsoft.Diagnostics.EventFlow.Outputs.EventHub**](https://www.nuget.org/packages/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/)
 
-> **BREAKING CHANGE**: Starting from version `2.0.0` this package targets _only_ `netstandard2.0`.
-
 This output writes data to the [Azure Event Hub](https://azure.microsoft.com/en-us/documentation/articles/event-hubs-overview/).
 
 Here is an example showing configuration using connection string:
@@ -1650,7 +1648,7 @@ The following table lists platform support for standard inputs and outputs.
 | *Outputs* |
 | [StdOutput (console output)](#stdoutput) | Yes | Yes | Yes |
 | [Application Insights](#application-insights) | Yes | Yes | Yes |
-| [Azure EventHub](#event-hub) | Yes | Yes | Yes |
+| [Azure EventHub](#event-hub) | No | Yes | Yes |
 | [Elasticsearch](#elasticsearch) | Yes | Yes | Yes |
 | [Azure Monitor Logs](#azure-monitor-logs) | Yes | Yes | Yes |
 | [HTTP (json via http)](#http) | Yes | Yes | Yes |

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/MemberInfoConverter.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/JsonConverters/MemberInfoConverter.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Diagnostics.EventFlow.JsonConverters
 {
-#if NET471 || NETSTANDARD2_0
+#if NET461 || NET471 || NETSTANDARD2_0
     public class MemberInfoConverter : JsonConverter<MemberInfo>
 #else
     public class MemberInfoConverter : JsonConverter
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.EventFlow.JsonConverters
         }
 #endif
 
-#if NET471 || NETSTANDARD2_0
+#if NET461 || NET471 || NETSTANDARD2_0
         public override MemberInfo ReadJson(JsonReader reader, Type objectType, MemberInfo existingValue, bool hasExistingValue, JsonSerializer serializer)
 #else
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.EventFlow.JsonConverters
             throw new NotImplementedException();
         }
 
-#if NET471 || NETSTANDARD2_0
+#if NET461 || NET471 || NETSTANDARD2_0
         public override void WriteJson(JsonWriter writer, MemberInfo value, JsonSerializer serializer)
 #else
         public void WriteJson(JsonWriter writer, MemberInfo value, JsonSerializer serializer)

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.10.1</VersionPrefix>
+    <VersionPrefix>1.10.2</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net452;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net452;net461;net471</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Core</PackageId>
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[1.1.1,2.0)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net471' ">
     <Reference Include="System.Web" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.EtwUtilities/Microsoft.Diagnostics.EventFlow.EtwUtilities.csproj
@@ -4,10 +4,10 @@
     <Description>Provides utility classes for processing data from Event Tracing for Windows (ETW) providers.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.6;net452;netstandard2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netstandard2.0;net461;net471</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.EtwUtilities</AssemblyName>
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.8.1</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.EtwUtilities</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Utilities;Event Tracing for Windows</PackageTags>
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[1.1.1,2.0)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net471' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Configuration/EventHubOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Configuration/EventHubOutputConfiguration.cs
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using Azure.Core;
+
 namespace Microsoft.Diagnostics.EventFlow.Configuration
 {
     // !!ACTION!!
@@ -11,6 +13,7 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
     {
         public string ConnectionString { get; set; }
         public bool UseAzureIdentity { get; set; }
+        public TokenCredential AzureTokenCredential { get; set; }
         public string FullyQualifiedNamespace { get; set; }
         public string EventHubName { get; set; }
         public string PartitionKeyProperty { get; set; }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Configuration/EventHubOutputConfiguration.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Configuration/EventHubOutputConfiguration.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Diagnostics.EventFlow.Configuration
     public class EventHubOutputConfiguration: ItemConfiguration
     {
         public string ConnectionString { get; set; }
+        public bool UseAzureIdentity { get; set; }
+        public string FullyQualifiedNamespace { get; set; }
         public string EventHubName { get; set; }
         public string PartitionKeyProperty { get; set; }
     }

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventDataExtensions.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventDataExtensions.cs
@@ -8,9 +8,7 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.Diagnostics.EventFlow.Metadata;
 using Newtonsoft.Json;
-using MessagingEventData = Microsoft.Azure.EventHubs.EventData;
-
-using Microsoft.Diagnostics.EventFlow;
+using MessagingEventData = Azure.Messaging.EventHubs.EventData;
 
 namespace Microsoft.Diagnostics.EventFlow.Outputs
 {
@@ -49,7 +47,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                 : ConvertToShoeboxTrace(eventData);
 
             // If this turns out to consume significant CPU time, we could serialize the object "manually".
-            // See https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.EventSource/EventSourceLogger.cs for an example.
+            // See https://github.com/dotnet/runtime/blob/0ea3b7d8cf957508a94061b8e921b28d6f6becd6/src/libraries/Microsoft.Extensions.Logging.EventSource/src/EventSourceLogger.cs for an example.
             // This avoids the reflection cost that is associate with single-call SerializeObject approach
             string eventDataSerialized = JsonConvert.SerializeObject(sbEventData, serializerSettings);
 

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventHubClientImpl.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventHubClientImpl.cs
@@ -3,34 +3,37 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs.Producer;
 using Validation;
+using MessagingEventData = Azure.Messaging.EventHubs.EventData;
 
 namespace Microsoft.Diagnostics.EventFlow.Outputs
 {
     internal class EventHubClientImpl : IEventHubClient
     {
-        private EventHubClient inner;
+        private EventHubProducerClient inner;
 
-        public EventHubClientImpl(EventHubClient inner)
+        public EventHubClientImpl(EventHubProducerClient inner)
         {
             Requires.NotNull(inner, nameof(inner));
             this.inner = inner;
         }
 
-        public Task SendAsync(IEnumerable<Azure.EventHubs.EventData> batch)
+        public Task SendAsync(IEnumerable<MessagingEventData> batch)
         {
             return this.inner.SendAsync(batch);
         }
 
-        public Task SendAsync(IEnumerable<Azure.EventHubs.EventData> batch, string partitionKey)
+        public Task SendAsync(IEnumerable<MessagingEventData> batch, string partitionKey)
         {
-            return this.inner.SendAsync(batch, partitionKey);
+            var sendOptions = new SendEventOptions
+            {
+                PartitionKey = partitionKey
+            };
+
+            return this.inner.SendAsync(batch, sendOptions);
         }
 
         public Task CloseAsync()

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventHubOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/EventHubOutput.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Identity;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
@@ -198,8 +199,10 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                     throw new Exception(emptyNamespaceMsg);
                 }
 
+                TokenCredential azureTokenCredential = this.outputConfiguration.AzureTokenCredential ?? new DefaultAzureCredential();
+
                 return new EventHubClientImpl(
-                    new EventHubProducerClient(this.outputConfiguration.FullyQualifiedNamespace, this.eventHubName, new DefaultAzureCredential())
+                    new EventHubProducerClient(this.outputConfiguration.FullyQualifiedNamespace, this.eventHubName, azureTokenCredential)
                 );
             }
 

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/IEventHubClient.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/IEventHubClient.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using MessagingEventData = Microsoft.Azure.EventHubs.EventData;
+using MessagingEventData = Azure.Messaging.EventHubs.EventData;
 
 namespace Microsoft.Diagnostics.EventFlow.Outputs
 {

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
@@ -4,17 +4,15 @@
     <Description>Provides an output implementation that sends diagnostics data to Azure Event Hubs.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net452;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</AssemblyName>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Event Hub;Event Hubs</PackageTags>
     <PackageProjectUrl>https://github.com/Azure/diagnostics-eventflow</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -25,19 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.4.1" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Validation" Version="2.4.18" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net452' ">
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DiagnosticsPipelineFactoryTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DiagnosticsPipelineFactoryTests.cs
@@ -379,6 +379,10 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                             ""serviceUri"": ""https://example.com/""
                         },
                         {
+                            ""type"": ""EventHub"",
+                            ""connectionString"": ""Endpoint=sb://unused.servicebus.windows.net/;SharedAccessKeyName=send-only;SharedAccessKey=+lw95uDEcOLYE/zZFycZx3gxgomPgzfFmSdj+iBQiI8=;EntityPath=hub1""
+                        },
+                        {
                             ""type"": ""ApplicationInsights"",
                             ""instrumentationKey"": ""00000000-0000-0000-0000-000000000000""
                         }
@@ -606,10 +610,8 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
 #endif
                             s => Assert.IsType<OmsOutput>(s.Output),
                             s => Assert.IsType<OmsOutput>(s.Output), // Azure Monitor Logs output can be created using the old and the new name
-                            s => Assert.IsType<HttpOutput>(s.Output)
-#if !NET461
-                            , s => Assert.IsType<EventHubOutput>(s.Output)
-#endif
+                            s => Assert.IsType<HttpOutput>(s.Output),
+                            s => Assert.IsType<EventHubOutput>(s.Output)
 #if NET461
                             , s => Assert.IsType<ApplicationInsightsOutput>(s.Output)
 #endif

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DiagnosticsPipelineFactoryTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DiagnosticsPipelineFactoryTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                         var eventSourceInput = pipeline.Inputs.First() as EventSourceInput;
                         Assert.NotNull(eventSourceInput);
 
-                        var expectedEventSources = new EventSourceConfiguration[3];                        
+                        var expectedEventSources = new EventSourceConfiguration[3];
                         expectedEventSources[0] = new EventSourceConfiguration { ProviderName = "Microsoft-ServiceFabric-Services" };
                         expectedEventSources[1] = new EventSourceConfiguration { ProviderName = "MyCompany-AirTrafficControlApplication-Frontend" };
                         // Microsoft-ApplicationInsights-Data is disabled by default to work around https://github.com/dotnet/coreclr/issues/14434
@@ -357,7 +357,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                             ""providers"": [
                                 { ""providerName"": ""Microsoft-ServiceFabric-Services"" },
                             ]
-                        }                        
+                        }
                     ],
 
                     ""outputs"": [
@@ -368,7 +368,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                             ""type"": ""OmsOutput"",
                             ""workspaceId"": ""00000000-0000-0000-0000-000000000000"",
                             ""workspaceKey"": ""Tm90IGEgd29ya3NwYWNlIGtleQ==""
-                        }, 
+                        },
                         {
                             ""type"": ""AzureMonitorLogs"",
                             ""workspaceId"": ""00000000-0000-0000-0000-000000000000"",
@@ -379,19 +379,15 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                             ""serviceUri"": ""https://example.com/""
                         },
                         {
-                            ""type"": ""EventHub"",
-                            ""connectionString"": ""Endpoint=sb://unused.servicebus.windows.net/;SharedAccessKeyName=send-only;SharedAccessKey=+lw95uDEcOLYE/zZFycZx3gxgomPgzfFmSdj+iBQiI8=;EntityPath=hub1""
-                        }, 
-                        {
                             ""type"": ""ApplicationInsights"",
                             ""instrumentationKey"": ""00000000-0000-0000-0000-000000000000""
-                        } 
+                        }
                     ],
 
                     ""schemaVersion"": ""2016-08-11""
                 }";
 #elif NET471
-             string pipelineConfiguration = @"
+            string pipelineConfiguration = @"
                 {
                     ""inputs"": [
                         {
@@ -425,7 +421,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                         {
                             ""type"": ""ElasticSearch"",
                             ""serviceUri"": ""https://myElasticSearchCluster:9200""
-                        }, 
+                        },
                         {
                             ""type"": ""OmsOutput"",
                             ""workspaceId"": ""00000000-0000-0000-0000-000000000000"",
@@ -439,6 +435,10 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                         {
                             ""type"": ""Http"",
                             ""serviceUri"": ""https://example.com/""
+                        },
+                        {
+                            ""type"": ""EventHub"",
+                            ""connectionString"": ""Endpoint=sb://unused.servicebus.windows.net/;SharedAccessKeyName=send-only;SharedAccessKey=+lw95uDEcOLYE/zZFycZx3gxgomPgzfFmSdj+iBQiI8=;EntityPath=hub1""
                         }
                     ],
 
@@ -485,7 +485,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                         {
                             ""type"": ""ElasticSearch"",
                             ""serviceUri"": ""https://myElasticSearchCluster:9200""
-                        }, 
+                        },
                         {
                             ""type"": ""OmsOutput"",
                             ""workspaceId"": ""00000000-0000-0000-0000-000000000000"",
@@ -499,12 +499,16 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                         {
                             ""type"": ""Http"",
                             ""serviceUri"": ""https://example.com/""
+                        },
+                        {
+                            ""type"": ""EventHub"",
+                            ""connectionString"": ""Endpoint=sb://unused.servicebus.windows.net/;SharedAccessKeyName=send-only;SharedAccessKey=+lw95uDEcOLYE/zZFycZx3gxgomPgzfFmSdj+iBQiI8=;EntityPath=hub1""
                         }
                     ],
 
                     ""schemaVersion"": ""2016-08-11""
                 }";
-#elif NET5_0 
+#elif NET5_0
             string pipelineConfiguration = @"
                 {
                     ""inputs"": [
@@ -541,7 +545,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                     ""outputs"": [
                         {
                             ""type"": ""StdOutput"",
-                        },                         
+                        },
                         {
                             ""type"": ""OmsOutput"",
                             ""workspaceId"": ""00000000-0000-0000-0000-000000000000"",
@@ -555,6 +559,10 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                         {
                             ""type"": ""Http"",
                             ""serviceUri"": ""https://example.com/""
+                        },
+                        {
+                            ""type"": ""EventHub"",
+                            ""connectionString"": ""Endpoint=sb://unused.servicebus.windows.net/;SharedAccessKeyName=send-only;SharedAccessKey=+lw95uDEcOLYE/zZFycZx3gxgomPgzfFmSdj+iBQiI8=;EntityPath=hub1""
                         }
                     ],
 
@@ -574,8 +582,8 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                     using (var pipeline = DiagnosticPipelineFactory.CreatePipeline(configuration))
                     {
                         Assert.NotNull(pipeline);
-                                                
-                        Assert.Collection(pipeline.Inputs, 
+
+                        Assert.Collection(pipeline.Inputs,
                             i => Assert.IsType<EventSourceInput>(i),
                             i => Assert.IsType<LoggerInput>(i),
                             i => Assert.IsType<TraceInput>(i),
@@ -590,7 +598,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                             , i => Assert.IsType<ActivitySourceInput>(i)
 #endif
                         );
-                        
+
                         Assert.Collection(pipeline.Sinks,
                             s => Assert.IsType<StdOutput>(s.Output),
 #if (!NET461 && !NET5_0)
@@ -599,8 +607,10 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                             s => Assert.IsType<OmsOutput>(s.Output),
                             s => Assert.IsType<OmsOutput>(s.Output), // Azure Monitor Logs output can be created using the old and the new name
                             s => Assert.IsType<HttpOutput>(s.Output)
-#if NET461
+#if !NET461
                             , s => Assert.IsType<EventHubOutput>(s.Output)
+#endif
+#if NET461
                             , s => Assert.IsType<ApplicationInsightsOutput>(s.Output)
 #endif
                         );

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Serilog\Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Log4net\Microsoft.Diagnostics.EventFlow.Inputs.Log4net.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.NLog\Microsoft.Diagnostics.EventFlow.Inputs.NLog.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.Oms\Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj" />
@@ -42,23 +43,16 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' " >
-    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
   </ItemGroup>
 

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Serilog\Microsoft.Diagnostics.EventFlow.Inputs.Serilog.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Log4net\Microsoft.Diagnostics.EventFlow.Inputs.Log4net.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.NLog\Microsoft.Diagnostics.EventFlow.Inputs.NLog.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj" />    
+    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.Oms\Microsoft.Diagnostics.EventFlow.Outputs.Oms.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj" />
   </ItemGroup>
@@ -27,7 +27,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter\Microsoft.Diagnostics.EventFlow.Inputs.PerformanceCounter.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.Etw\Microsoft.Diagnostics.EventFlow.Inputs.Etw.csproj" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.11" />
@@ -41,6 +40,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' " >
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' " >
+    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
@@ -58,7 +61,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Elasticsearch.Net" Version="[7.1.0, 8.0)" />

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/EventHubOutputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/EventHubOutputTests.cs
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-#if NETCOREAPP2_1_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,7 +30,8 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
             e.Payload.Add("DateTimeOffsetProperty", new DateTimeOffset(2017, 4, 19, 10, 16, 07, TimeSpan.Zero));
 
             var messagingData = EventDataExtensions.ToMessagingEventData(e, EventFlowJsonUtilities.GetDefaultSerializerSettings(), out int messageSize);
-            string messageBody = Encoding.UTF8.GetString(messagingData.EventBody);
+            var messagingDataBytes = messagingData.EventBody.ToArray();
+            string messageBody = Encoding.UTF8.GetString(messagingDataBytes, (int)messagingData.Offset, messagingDataBytes.Length);
 
             var dateTimeRegex = new Regex(@"""DateTimeProperty"" \s* : \s* ""2017-04-19T10:15:23Z""", RegexOptions.IgnorePatternWhitespace, TimeSpan.FromMilliseconds(100));
             Assert.Matches(dateTimeRegex, messageBody);
@@ -64,7 +64,8 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 if (batch.Count() != 1) return false;
 
                 var data = batch.First();
-                var bodyString = Encoding.UTF8.GetString(data.EventBody);
+                var dataBytes = data.EventBody.ToArray();
+                var bodyString = Encoding.UTF8.GetString(dataBytes, (int)data.Offset, dataBytes.Length);
                 var recordSet = JObject.Parse(bodyString);
                 var message = recordSet["records"][0];
 
@@ -216,7 +217,8 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 if (batch.Count() != 1) return false;
 
                 var data = batch.First();
-                var bodyString = Encoding.UTF8.GetString(data.EventBody);
+                var dataBytes = data.EventBody.ToArray();
+                var bodyString = Encoding.UTF8.GetString(dataBytes, (int)data.Offset, dataBytes.Length);
                 var recordSet = JObject.Parse(bodyString);
                 var message = recordSet["records"][0];
 
@@ -253,7 +255,8 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 if (batch.Count() != 1) return false;
 
                 var data = batch.First();
-                var bodyString = Encoding.UTF8.GetString(data.EventBody);
+                var dataBytes = data.EventBody.ToArray();
+                var bodyString = Encoding.UTF8.GetString(dataBytes, (int)data.Offset, dataBytes.Length);
                 var recordSet = JObject.Parse(bodyString);
                 var message = recordSet["records"][0];
 
@@ -276,7 +279,8 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 if (batch.Count() != 1) return false;
 
                 var data = batch.First();
-                var bodyString = Encoding.UTF8.GetString(data.EventBody);
+                var dataBytes = data.EventBody.ToArray();
+                var bodyString = Encoding.UTF8.GetString(dataBytes, (int)data.Offset, dataBytes.Length);
                 var recordSet = JObject.Parse(bodyString);
                 var message = recordSet["records"][0];
 
@@ -293,4 +297,3 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
         }
     }
 }
-#endif

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/EventHubOutputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/EventHubOutputTests.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+#if NETCOREAPP2_1_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,7 +15,7 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using MessagingEventData = Microsoft.Azure.EventHubs.EventData;
+using MessagingEventData = Azure.Messaging.EventHubs.EventData;
 
 using Microsoft.Diagnostics.EventFlow.Configuration;
 
@@ -30,7 +31,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
             e.Payload.Add("DateTimeOffsetProperty", new DateTimeOffset(2017, 4, 19, 10, 16, 07, TimeSpan.Zero));
 
             var messagingData = EventDataExtensions.ToMessagingEventData(e, EventFlowJsonUtilities.GetDefaultSerializerSettings(), out int messageSize);
-            string messageBody = Encoding.UTF8.GetString(messagingData.Body.Array, messagingData.Body.Offset, messagingData.Body.Count);
+            string messageBody = Encoding.UTF8.GetString(messagingData.EventBody);
 
             var dateTimeRegex = new Regex(@"""DateTimeProperty"" \s* : \s* ""2017-04-19T10:15:23Z""", RegexOptions.IgnorePatternWhitespace, TimeSpan.FromMilliseconds(100));
             Assert.Matches(dateTimeRegex, messageBody);
@@ -63,7 +64,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 if (batch.Count() != 1) return false;
 
                 var data = batch.First();
-                var bodyString = Encoding.UTF8.GetString(data.Body.Array, data.Body.Offset, data.Body.Count);
+                var bodyString = Encoding.UTF8.GetString(data.EventBody);
                 var recordSet = JObject.Parse(bodyString);
                 var message = recordSet["records"][0];
 
@@ -215,7 +216,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 if (batch.Count() != 1) return false;
 
                 var data = batch.First();
-                var bodyString = Encoding.UTF8.GetString(data.Body.Array, data.Body.Offset, data.Body.Count);
+                var bodyString = Encoding.UTF8.GetString(data.EventBody);
                 var recordSet = JObject.Parse(bodyString);
                 var message = recordSet["records"][0];
 
@@ -252,7 +253,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 if (batch.Count() != 1) return false;
 
                 var data = batch.First();
-                var bodyString = Encoding.UTF8.GetString(data.Body.Array, data.Body.Offset, data.Body.Count);
+                var bodyString = Encoding.UTF8.GetString(data.EventBody);
                 var recordSet = JObject.Parse(bodyString);
                 var message = recordSet["records"][0];
 
@@ -275,7 +276,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
                 if (batch.Count() != 1) return false;
 
                 var data = batch.First();
-                var bodyString = Encoding.UTF8.GetString(data.Body.Array, data.Body.Offset, data.Body.Count);
+                var bodyString = Encoding.UTF8.GetString(data.EventBody);
                 var recordSet = JObject.Parse(bodyString);
                 var message = recordSet["records"][0];
 
@@ -292,3 +293,4 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
         }
     }
 }
+#endif

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj" />
-    <ProjectReference Condition=" '$(TargetFramework)' != 'net471' " Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
   </ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput\Microsoft.Diagnostics.EventFlow.Outputs.StdOutput.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput\Microsoft.Diagnostics.EventFlow.Outputs.HttpOutput.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
+    <ProjectReference Condition=" '$(TargetFramework)' != 'net471' " Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.EventHub\Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights\Microsoft.Diagnostics.EventFlow.Outputs.ApplicationInsights.csproj" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates EventHub output package to use `Azure.*` libraries and adds support for using "Azure Identity" for EventHub authentication (instead of Connection Strings).

BREAKING CHANGES: because `Azure.Messaging.EventHubs` only targets `netstandard2.0` this new package also targets only `nestandard2.0`. 