### PR TITLE
Fix precise timestamp with .NET 4.6.1

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DateTimePrecise.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Implementations/DateTimePrecise.cs
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------
 
 using System;
-#if NET452 || NET471
+#if NET461 || NET471
 using System.Runtime.InteropServices;
 #endif
 
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.EventFlow
 {
     public static class DateTimePrecise
     {
-#if NET452 || NET471
+#if NET461 || NET471
         [DllImport("Kernel32.dll", CallingConvention = CallingConvention.Winapi)]
         private static extern void GetSystemTimePreciseAsFileTime(out long filetime);
 
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.EventFlow
         {
             get
             {
-#if NET452 || NET471
+#if NET461 || NET471
                 if (UseSystemTimePrecise)
                 {
                     GetSystemTimePreciseAsFileTime(out var filetime);

--- a/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Core/Microsoft.Diagnostics.EventFlow.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Defines core interfaces and types that comprise Microsoft.Diagnostics.EventFlow library.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.10.2</VersionPrefix>
+    <VersionPrefix>1.10.3</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net452;net461;net471</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core</AssemblyName>


### PR DESCRIPTION
Fixes https://github.com/Azure/diagnostics-eventflow/issues/392