### PR TITLE
Fixed issue when EventFlowLogger throws on duplicate log message arguments

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLogger.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLogger.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
 
             Dictionary<string, object> properties = new Dictionary<string, object>();
 
-            ApplyOmittingUnformattedMessage(state, item => properties.Add(item.Key, item.Value));
+            ApplyOmittingUnformattedMessage(state, item => AddPayloadProperty(properties, item.Key, item.Value));
 
             var scope = EventFlowLoggerScope.Current;
             if (scope != null)

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLogger.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Logger/EventFlowLogger.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs
 
             Dictionary<string, object> properties = new Dictionary<string, object>();
 
-            ApplyOmittingUnformattedMessage(state, item => AddPayloadProperty(properties, item.Key, item.Value));
+            ApplyOmittingUnformattedMessage(state, item => properties[item.Key] = item.Value);
 
             var scope = EventFlowLoggerScope.Current;
             if (scope != null)

--- a/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging/Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net462</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</AssemblyName>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.6.1</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Inputs.MicrosoftLogging</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Inputs;MicrosoftLogging</PackageTags>


### PR DESCRIPTION
This PR fixes an issue when EventFlowLogger throws when encounter log message with duplicate argument names.

While one can argue that log messages should maybe not have duplicate argument names and log messages should be fixed instead, it is possible to encounter such logs in 3rd-party libraries.

For example, Orleans 3.x has such log: 
https://github.com/dotnet/orleans/blob/54382a15b653f80784520c9055614cbf429a1b16/src/Orleans.Runtime/GrainDirectory/AdaptiveDirectoryCacheMaintainer.cs#L80
![image](https://user-images.githubusercontent.com/3368120/185200006-ccfa204e-ee10-48dd-9ab3-ddd4980a1c9d.png)
