### PR TITLE
Build/test fixes

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,8 +1,6 @@
-* Prerequisites
-    * Visual Studio 2017
-	* .NET Framework 4.7.1 SDK and Targeting Pack
-	* .NET Core 1.0 SDK
-	* .NET Core 2.0 SDK
+* Prerequisites for full build:
+    * Visual Studio 2022
+	* .NET Framework SDKs/Targeting Packs for .NET 6, .NET Framework 4.6.2 and .NET Framework 4.7.1.
 
 * Build
 
@@ -10,8 +8,6 @@
 
         tools\scorch.cmd
         tools\restore.cmd
-    
-    *You must run `tools\restore.cmd` at least once before attempting to build or run tests*, otherwise you will encouter errors such as "missing FileParser.peg.cs file".
     
     Run the following command to build a release build:
 

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net471;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net471;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -35,32 +35,16 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'netcoreapp3.1' " >
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net471'" >
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch\Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'netcoreapp3.1' " >
-    <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-  </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-	    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-	    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-	    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    </ItemGroup>
+<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+  <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+  <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource.csproj" />
+</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net471;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -27,18 +27,11 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource.csproj" />
   </ItemGroup>
 
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">    
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />    
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.11" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.11" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net471;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>
@@ -23,10 +23,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net471;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net471;net6.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests</AssemblyName>

--- a/tools/buildRelease.cmd
+++ b/tools/buildRelease.cmd
@@ -1,4 +1,4 @@
 @ECHO OFF
 pushd %~dp0..
-dotnet build /m /p:Configuration=Release /binaryLogger /verbosity:minimal
+dotnet build /m /p:Configuration=Release /binaryLogger /verbosity:minimal Warsaw.sln
 popd

--- a/tools/restore.cmd
+++ b/tools/restore.cmd
@@ -1,5 +1,5 @@
 @ECHO OFF
-dotnet restore --force %~dp0..\
+dotnet restore --force %~dp0..\Warsaw.sln
 pushd %~dp0..
 tools\nuget.exe restore "src\Microsoft.Diagnostics.EventFlow.Signing\Microsoft.Diagnostics.EventFlow.Signing.csproj" -PackagesDirectory packages
 tools\nuget.exe restore "src\Microsoft.Diagnostics.EventFlow.NugetSigning\Microsoft.Diagnostics.EventFlow.NugetSigning.csproj" -PackagesDirectory packages


### PR DESCRIPTION
Noticed our build scripts no longer work with latest MSBuild tooling. Fixed.
Also disabled running tests on .NET Core 3.1 since it is out of support. 