### PR TITLE
Fix ElasticSearch index name formatting

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/ElasticSearchOutput.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
 
         private enum FormatIndexType {QuarterOfYear, WeekOfMonth, WeekOfYearDoubleDigit, WeekOfYear}
 
-        private class FormatIndex: IComparable<FormatIndex>
+        private class FormatIndex: IComparable<FormatIndex>, IEquatable<FormatIndex>
         {
             public FormatIndex(int index, FormatIndexType formatIndexType)
             {
@@ -54,6 +54,17 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs
                 if (Index < other.Index) return 1;
                 return Index > other.Index? -1 : 0;
             }
+
+            public override bool Equals(object obj)
+            {
+                FormatIndex other = obj as FormatIndex;
+                if (other is null) return false;
+                return Index == other.Index;
+            }
+
+            public bool Equals(FormatIndex other) => Index == other.Index;
+
+            public override int GetHashCode() => Index.GetHashCode();
         }
 
         private FormatIndex[] formatIndexes;

--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch/Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Provides an output implementation that sends diagnostics data to Elasticsearch.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>2.7.5</VersionPrefix>
+    <VersionPrefix>2.7.6</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net471;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.ElasticSearch</AssemblyName>

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EtwInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EtwInputTests.cs
@@ -185,8 +185,8 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
 
                 // Activation of the input causes creation of an ETW listening session in a separate Task.
                 // It takes a bit of time for the session to start capturing events.
-                // Use a small delay to minimize the chance that the following exception will be missed.
-                await Task.Delay(TimeSpan.FromMilliseconds(500));
+                // Use a delay to minimize the chance that the following exception will be missed.
+                await Task.Delay(TraceSessionActivationTimeout);
                 
                 try
                 {

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/ElasticSearchOutputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/ElasticSearchOutputTests.cs
@@ -109,10 +109,10 @@ namespace Microsoft.Diagnostics.EventFlow.Outputs.Tests
         [InlineData(2023, 4, 2, "yyyy.WW", "2023.w14")]
         [InlineData(2023, 2, 2, "yyyy.MM.w.W", "2023.02.w1.w5")]
         [InlineData(2023, 2, 2, "yyyy.MM.w.WW", "2023.02.w1.w05")]
-        [InlineData(2023, 2, 2, "yyyy.q.w", "2023.q1.w5")]
+        [InlineData(2023, 2, 2, "yyyy.q.w", "2023.q1.w1")]
         [InlineData(2023, 2, 2, "yyyy.q.W", "2023.q1.w5")]
         [InlineData(2023, 2, 2, "yyyy.q.WW", "2023.q1.w05")]
-        [InlineData(2023, 2, 2, "yyyy.W.WW", "2023.W.w14")]
+        [InlineData(2023, 2, 2, "yyyy.W.WW", "2023.w5.w05")]
         public void VerifyIndexFormatValues(int year, int month, int day, string formatString, string expectedValue)
         {
             var dateTimeOffset = new DateTimeOffset(year, month, day, 0, 0, 0, DateTimeOffset.UtcNow.Offset);


### PR DESCRIPTION
A relatively minor fix to make all cases work as intended