### PR TITLE
Update EventHub output

### DIFF
--- a/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
+++ b/src/Microsoft.Diagnostics.EventFlow.Outputs.EventHub/Microsoft.Diagnostics.EventFlow.Outputs.EventHub.csproj
@@ -6,7 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</AssemblyName>
-    <VersionPrefix>2.0.4</VersionPrefix>
+    <VersionPrefix>2.0.5</VersionPrefix>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.Diagnostics.EventFlow.Outputs.EventHub</PackageId>
     <PackageTags>Microsoft;Diagnostics;EventFlow;Outputs;Event Hub;Event Hubs</PackageTags>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.2" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Validation" Version="2.4.18" />

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DiagnosticsPipelineFactoryTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/DiagnosticsPipelineFactoryTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Diagnostics.EventFlow.Configuration;
 using Microsoft.Diagnostics.EventFlow.Filters;
 using Microsoft.Diagnostics.EventFlow.HealthReporters;
 using Microsoft.Diagnostics.EventFlow.Inputs;
-#if NET7_0 || NET6_0 || NETCOREAPP2_1 || NETCOREAPP3_1
+#if NET8_0 || NET6_0 || NETCOREAPP2_1 || NETCOREAPP3_1
 using Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource;
 #endif
 using Microsoft.Diagnostics.EventFlow.Metadata;
@@ -512,7 +512,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
 
                     ""schemaVersion"": ""2016-08-11""
                 }";
-#elif NET6_0 || NET7_0
+#elif NET6_0 || NET8_0
             string pipelineConfiguration = @"
                 {
                     ""inputs"": [
@@ -598,14 +598,14 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
                             , i => Assert.IsType<PerformanceCounterInput>(i)
                             , i => Assert.IsType<EtwInput>(i)
 #endif
-#if NET7_0 || NET6_0 || NETCOREAPP2_1 || NETCOREAPP3_1
+#if NET8_0 || NET6_0 || NETCOREAPP2_1 || NETCOREAPP3_1
                             , i => Assert.IsType<ActivitySourceInput>(i)
 #endif
                         );
 
                         Assert.Collection(pipeline.Sinks,
                             s => Assert.IsType<StdOutput>(s.Output),
-#if (!NET462 && !NET6_0 && !NET7_0)
+#if (!NET462 && !NET6_0 && !NET8_0)
                             s => Assert.IsType<ElasticSearchOutput>(s.Output),
 #endif
                             s => Assert.IsType<OmsOutput>(s.Output),

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/MetadataTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/MetadataTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
             Assert.Equal("200 OK", rd.ResponseCode);
 
             // Note the TimeSpan.FromMilliseconds will round to the nearest millisecond on everything older than .NET Core 3.0
-#if NETCOREAPP3_1 || NET6_0 || NET7_0
+#if NETCOREAPP3_1 || NET6_0 || NET8_0
             Assert.Equal(34.7, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
 #else
             Assert.Equal(35, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
@@ -155,7 +155,7 @@ namespace Microsoft.Diagnostics.EventFlow.Core.Tests
             eventData.Payload["duration"] = 65.7;
             result = RequestData.TryGetData(eventData, requestMetadata, out rd);
             Assert.Equal(DataRetrievalStatus.Success, result.Status);
-#if NETCOREAPP3_1 || NET6_0 || NET7_0
+#if NETCOREAPP3_1 || NET6_0 || NET8_0
             Assert.Equal(65.7, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);
 #else
             Assert.Equal(66, rd.Duration.Value.TotalMilliseconds, DoublePrecisionTolerance);

--- a/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Core.Tests/Microsoft.Diagnostics.EventFlow.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net471;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net471;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Core.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -46,10 +46,10 @@
     <ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
-	<PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-	<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+	<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 	<ProjectReference Include="..\..\src\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource\Microsoft.Diagnostics.EventFlow.Inputs.ActivitySource.csproj" />
   </ItemGroup>
 

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EventSourceInputTests.cs
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/EventSourceInputTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Diagnostics.EventFlow.Inputs.Tests
                 Assert.Equal("EventCounters", data.Payload["EventName"]);
                 Assert.Equal("testCounter", data.Payload["Name"]);
                 Assert.Equal(2, data.Payload["Count"]);
-#if NETCOREAPP3_1 || NET6_0 || NET7_0
+#if NETCOREAPP3_1 || NET6_0 || NET8_0
                 Assert.Equal((double)5, data.Payload["Max"]);
                 Assert.Equal((double)1, data.Payload["Min"]);
 #else

--- a/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Inputs.Tests/Microsoft.Diagnostics.EventFlow.Inputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net471;net6.0;net8.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Inputs.Tests</AssemblyName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.Outputs.Tests/Microsoft.Diagnostics.EventFlow.Outputs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net471;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.Outputs.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>

--- a/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
+++ b/test/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests/Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net471;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net471;net6.0;net8.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Diagnostics.EventFlow.ServiceFabric.Tests</AssemblyName>


### PR DESCRIPTION
The new dependency has vulnerability fixes.

This change also stops running tests on .NET 7 and starts running them on .NET 8.